### PR TITLE
Add a test for new `Hsteps` keyword argument

### DIFF
--- a/micromagnetictests/calculatortests/__init__.py
+++ b/micromagnetictests/calculatortests/__init__.py
@@ -9,7 +9,7 @@ from .dynamics import TestDynamics
 from .energy import TestEnergy
 from .exchange import TestExchange
 from .fixedsubregions import TestFixedSubregions
-from .hysteresisdriver import test_simple_hysteresis_loop
+from .hysteresisdriver import TestHysteresisDriver
 from .info_file import test_info_file
 from .mesh import TestMesh
 from .mindriver import TestMinDriver

--- a/micromagnetictests/calculatortests/__init__.py
+++ b/micromagnetictests/calculatortests/__init__.py
@@ -9,7 +9,7 @@ from .dynamics import TestDynamics
 from .energy import TestEnergy
 from .exchange import TestExchange
 from .fixedsubregions import TestFixedSubregions
-from .hysteresisdriver import TestHysteresisDriver
+from .hysteresisdriver import test_simple_hysteresis_loop, test_stepped_hysteresis_loop
 from .info_file import test_info_file
 from .mesh import TestMesh
 from .mindriver import TestMinDriver

--- a/micromagnetictests/calculatortests/__init__.py
+++ b/micromagnetictests/calculatortests/__init__.py
@@ -9,7 +9,11 @@ from .dynamics import TestDynamics
 from .energy import TestEnergy
 from .exchange import TestExchange
 from .fixedsubregions import TestFixedSubregions
-from .hysteresisdriver import test_check_for_energy, test_simple_hysteresis_loop, test_stepped_hysteresis_loop
+from .hysteresisdriver import (
+    test_check_for_energy,
+    test_simple_hysteresis_loop,
+    test_stepped_hysteresis_loop,
+)
 from .info_file import test_info_file
 from .mesh import TestMesh
 from .mindriver import TestMinDriver

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -1,32 +1,65 @@
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
+import pytest
 
 
-def test_simple_hysteresis_loop(calculator):
-    """Simple hysteresis loop between Hmin and Hmax with symmetric number of steps."""
-    system = mm.System(name="hysteresisdriver_noevolver_nodriver")
+class TestHysteresisDriver:
+    @pytest.fixture(autouse=True)
+    def _setup_calculator(self, calculator):
+        self.calculator = calculator
 
-    A = 1e-12
-    H = (0, 0, 1e6)
-    system.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
+    def setup_method(self):
+        p1 = (0, 0, 0)
+        p2 = (5e-9, 5e-9, 5e-9)
+        n = (5, 5, 5)
+        self.Ms = 1e6
+        A = 1e-12
+        H = (0, 0, 1e6)
+        region = df.Region(p1=p1, p2=p2)
+        self.mesh = df.Mesh(region=region, n=n)
+        self.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
+        self.m = df.Field(self.mesh, nvdim=3, value=(0, 1, 0), norm=self.Ms)
 
-    p1 = (0, 0, 0)
-    p2 = (5e-9, 5e-9, 5e-9)
-    n = (5, 5, 5)
-    Ms = 1e6
-    region = df.Region(p1=p1, p2=p2)
-    mesh = df.Mesh(region=region, n=n)
-    system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
+    def test_simple_hysteresis_loop(self):
+        """Simple hysteresis loop between Hmin and Hmax with symmetric number of steps."""
+        name = "hysteresisdriver_noevolver_nodriver"
 
-    hd = calculator.HysteresisDriver()
-    hd.drive(system, Hmin=(0, 0, -1e6), Hmax=(0, 0, 1e6), n=3)
+        system = mm.System(name=name)
+        system.energy = self.energy
+        system.m = self.m
 
-    value = system.m(mesh.region.random_point())
-    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+        hd = self.calculator.HysteresisDriver()
+        hd.drive(system, Hmin=(0, 0, -1e6), Hmax=(0, 0, 1e6), n=3)
 
-    assert len(system.table.data.index) == 5
+        value = system.m(self.mesh.region.random_point())
+        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
 
-    assert system.table.x == "B_hysteresis"
+        assert len(system.table.data.index) == 5
 
-    calculator.delete(system)
+        assert system.table.x == "B_hysteresis"
+
+        self.calculator.delete(system)
+
+    def test_stepped_hysteresis_loop(self):
+        """Same as in the test above, but by using `Hsteps` as keyword argument."""
+        name = "hysteresisdriver_noevolver_nodriver"
+
+        system = mm.System(name=name)
+        system.energy = self.energy
+        system.m = self.m
+
+        hd = self.calculator.HysteresisDriver()
+        hd.drive(system, Hsteps=[
+            [(0, 0, -1e6), (0, 0, 1e6), 3],
+            [(0, 0, 1e6), (0, 0, -1e6), 3],
+        ])
+
+        value = system.m(self.mesh.region.random_point())
+        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+
+        assert len(system.table.data.index) == 5
+
+        assert system.table.x == "B_hysteresis"
+
+        self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -42,20 +42,20 @@ def test_simple_hysteresis_loop(calculator, system, Ms):
 
 
 def test_stepped_hysteresis_loop(calculator, system, Ms):
-    """Simple hysteresis loop using `Hsteps` as keyword argument."""
+    """Simple hysteresis loop with uneven steps using `Hsteps` as keyword argument."""
     hd = calculator.HysteresisDriver()
     hd.drive(
         system,
         Hsteps=[
             [(0, 0, -1e6), (0, 0, 1e6), 3],
-            [(0, 0, 1e6), (0, 0, -1e6), 3],
+            [(0, 0, 1e6), (0, 0, -1e6), 5],
         ],
     )
 
     value = system.m(self.mesh.region.random_point())
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    assert len(system.table.data.index) == 5
+    assert len(system.table.data.index) == 7
 
     assert system.table.x == "B_hysteresis"
 

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -31,7 +31,7 @@ def test_simple_hysteresis_loop(calculator, system, Ms):
     hd = calculator.HysteresisDriver()
     hd.drive(system, Hmin=(0, 0, -1e6), Hmax=(0, 0, 1e6), n=3)
 
-    value = system.m(mesh.region.random_point())
+    value = system.m(system.m.mesh.region.random_point())
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
     assert len(system.table.data.index) == 5
@@ -52,7 +52,7 @@ def test_stepped_hysteresis_loop(calculator, system, Ms):
         ],
     )
 
-    value = system.m(self.mesh.region.random_point())
+    value = system.m(system.m.mesh.region.random_point())
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
     assert len(system.table.data.index) == 7

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -69,4 +69,3 @@ def test_check_for_energy(calculator):
 
     with pytest.raises(RuntimeError, match="System's energy is not defined"):
         hd.drive(system, Hmin=(0, 0, -1e6), Hmax=(0, 0, 1e6), n=3)
-

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -50,10 +50,13 @@ class TestHysteresisDriver:
         system.m = self.m
 
         hd = self.calculator.HysteresisDriver()
-        hd.drive(system, Hsteps=[
-            [(0, 0, -1e6), (0, 0, 1e6), 3],
-            [(0, 0, 1e6), (0, 0, -1e6), 3],
-        ])
+        hd.drive(
+            system,
+            Hsteps=[
+                [(0, 0, -1e6), (0, 0, 1e6), 3],
+                [(0, 0, 1e6), (0, 0, -1e6), 3],
+            ],
+        )
 
         value = system.m(self.mesh.region.random_point())
         assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -12,7 +12,7 @@ def Ms():
 @pytest.fixture
 def system(Ms):
     system = mm.System(name="hysteresisdriver_noevolver_nodriver")
-    
+
     A = 1e-12
     H = (0, 0, 1e6)
     system.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)

--- a/micromagnetictests/calculatortests/hysteresisdriver.py
+++ b/micromagnetictests/calculatortests/hysteresisdriver.py
@@ -4,65 +4,59 @@ import numpy as np
 import pytest
 
 
-class TestHysteresisDriver:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def Ms():
+    return 1e6
 
-    def setup_method(self):
-        p1 = (0, 0, 0)
-        p2 = (5e-9, 5e-9, 5e-9)
-        n = (5, 5, 5)
-        self.Ms = 1e6
-        A = 1e-12
-        H = (0, 0, 1e6)
-        region = df.Region(p1=p1, p2=p2)
-        self.mesh = df.Mesh(region=region, n=n)
-        self.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
-        self.m = df.Field(self.mesh, nvdim=3, value=(0, 1, 0), norm=self.Ms)
 
-    def test_simple_hysteresis_loop(self):
-        """Simple hysteresis loop between Hmin and Hmax with symmetric number of steps."""
-        name = "hysteresisdriver_noevolver_nodriver"
+@pytest.fixture
+def system(Ms):
+    system = mm.System(name="hysteresisdriver_noevolver_nodriver")
+    
+    A = 1e-12
+    H = (0, 0, 1e6)
+    system.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
+    p1 = (0, 0, 0)
+    p2 = (5e-9, 5e-9, 5e-9)
+    n = (5, 5, 5)
+    region = df.Region(p1=p1, p2=p2)
+    mesh = df.Mesh(region=region, n=n)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
+    return system
 
-        hd = self.calculator.HysteresisDriver()
-        hd.drive(system, Hmin=(0, 0, -1e6), Hmax=(0, 0, 1e6), n=3)
 
-        value = system.m(self.mesh.region.random_point())
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+def test_simple_hysteresis_loop(calculator, system, Ms):
+    """Simple hysteresis loop between Hmin and Hmax with symmetric number of steps."""
+    hd = calculator.HysteresisDriver()
+    hd.drive(system, Hmin=(0, 0, -1e6), Hmax=(0, 0, 1e6), n=3)
 
-        assert len(system.table.data.index) == 5
+    value = system.m(mesh.region.random_point())
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        assert system.table.x == "B_hysteresis"
+    assert len(system.table.data.index) == 5
 
-        self.calculator.delete(system)
+    assert system.table.x == "B_hysteresis"
 
-    def test_stepped_hysteresis_loop(self):
-        """Same as in the test above, but by using `Hsteps` as keyword argument."""
-        name = "hysteresisdriver_noevolver_nodriver"
+    calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
 
-        hd = self.calculator.HysteresisDriver()
-        hd.drive(
-            system,
-            Hsteps=[
-                [(0, 0, -1e6), (0, 0, 1e6), 3],
-                [(0, 0, 1e6), (0, 0, -1e6), 3],
-            ],
-        )
+def test_stepped_hysteresis_loop(calculator, system, Ms):
+    """Simple hysteresis loop using `Hsteps` as keyword argument."""
+    hd = calculator.HysteresisDriver()
+    hd.drive(
+        system,
+        Hsteps=[
+            [(0, 0, -1e6), (0, 0, 1e6), 3],
+            [(0, 0, 1e6), (0, 0, -1e6), 3],
+        ],
+    )
 
-        value = system.m(self.mesh.region.random_point())
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+    value = system.m(self.mesh.region.random_point())
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        assert len(system.table.data.index) == 5
+    assert len(system.table.data.index) == 5
 
-        assert system.table.x == "B_hysteresis"
+    assert system.table.x == "B_hysteresis"
 
-        self.calculator.delete(system)
+    calculator.delete(system)

--- a/micromagnetictests/tests/test_get_tests.py
+++ b/micromagnetictests/tests/test_get_tests.py
@@ -3,4 +3,4 @@ import micromagnetictests as mt
 
 def test_get_tests():
     tests = list(mt.get_tests())
-    assert len(tests) == 30
+    assert len(tests) == 31

--- a/micromagnetictests/tests/test_get_tests.py
+++ b/micromagnetictests/tests/test_get_tests.py
@@ -3,4 +3,4 @@ import micromagnetictests as mt
 
 def test_get_tests():
     tests = list(mt.get_tests())
-    assert len(tests) == 31
+    assert len(tests) == 34


### PR DESCRIPTION
Implementing a necessary new test for PR https://github.com/ubermag/oommfc/pull/138 (Adding Hsteps as new keyword argument to HysteresisDriver for stepped hysteresis loops).

Test structure of new `TestHysteresisDriver` class is now (again) similar to already existing `TestMinDriver` class.

Just a draft idea, if you want to, we could also just write a second function. IMHO the class structure is nicer.