### PR TITLE
remove classes

### DIFF
--- a/micromagnetictests/calculatortests/__init__.py
+++ b/micromagnetictests/calculatortests/__init__.py
@@ -1,291 +1,55 @@
 """Calculator tests."""
 
-from .compute import (
-    compute_case,
-    test_compute_dmi,
-    test_compute_effective_field,
-    test_compute_energy,
-    test_compute_energy_density,
-    test_compute_invalid_func,
-    test_compute_slonczewski,
-    test_compute_zhang_li,
-)
-from .cubicanisotropy import (
-    cubic_anisotropy_case,
-    test_cubic_anisotropy_dict_vector_vector,
-    test_cubic_anisotropy_field_field_field,
-    test_cubic_anisotropy_field_vector_vector,
-    test_cubic_anisotropy_scalar_vector_vector,
-)
-from .damping import (
-    damping_case,
-    test_damping_dict,
-    test_damping_field,
-    test_damping_scalar,
-)
-from .demag import (
-    demag_case,
-    test_demag_demag,
-    test_demag_demag_1_pbc,
-    test_demag_demag_2_pbc,
-    test_demag_demag_3_pbc,
-    test_demag_demag_asymptotic_radius,
-)
-from .dirname import test_dirname
-from .dmi import (
-    dmi_case,
-    test_dmi_crystalclass,
-    test_dmi_crystalclass_init,
-    test_dmi_dict,
-    test_dmi_scalar,
-)
-from .dynamics import (
-    dynamics_case,
-    test_dynamics_field_field,
-    test_dynamics_scalar_dict,
-    test_dynamics_scalar_scalar,
-)
-from .energy import (
-    energy_case,
-    test_energy_exchange_cubicanisotropy,
-    test_energy_exchange_dmi_zeeman,
-    test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag,
-    test_energy_exchange_uniaxialanisotropy,
-    test_energy_exchange_zeeman,
-    test_energy_zeeman_zeeman,
-)
-from .exchange import (
-    exchange_case,
-    test_exchange_dict,
-    test_exchange_field,
-    test_exchange_scalar,
-)
-from .fixedsubregions import (
-    fixed_subregions_case,
-    test_fixed_subregions_fixed_subregions,
-)
-from .hysteresisdriver import (
-    Ms,
-    system,
-    test_hysteresis_check_for_energy,
-    test_simple_hysteresis_loop,
-    test_stepped_hysteresis_loop,
-)
-from .info_file import test_info_file
-from .mesh import (
-    mesh_case,
-    test_mesh_multi_nopbc,
-    test_mesh_multi_pbc,
-    test_mesh_single_nopbc,
-    test_mesh_single_pbc,
-)
-from .mindriver import (
-    min_driver_case,
-    test_min_driver_check_for_energy,
-    test_min_driver_evolver_driver,
-    test_min_driver_evolver_nodriver,
-    test_min_driver_noevolver_driver,
-    test_min_driver_noevolver_nodriver,
-    test_min_driver_output_files,
-    test_min_driver_wrong_evolver,
-)
-from .multiple_drives import test_multiple_drives, test_multiple_drives_compute
-from .outputformat import test_format
-from .outputstep import test_outputstep
-from .precession import (
-    precession_case,
-    test_precession_dict,
-    test_precession_field,
-    test_precession_scalar,
-)
-from .relaxdriver import test_relax_check_for_energy, test_relaxdriver
-from .rkky import rkky_case, test_rkky_scalar
-from .schedule import test_schedule
-from .skyrmion import test_skyrmion
-from .slonczewski import (
-    slonczewski_case,
-    test_slonczewski_dict_values,
-    test_slonczewski_field_values,
-    test_slonczewski_single_values,
-    test_slonczewski_single_values_finite_temperature,
-)
-from .stdprob3 import test_stdprob3
-from .stdprob4 import test_stdprob4
-from .stdprob5 import test_stdprob5
-from .threads import test_threads_threads, threads_case
-from .timedriver import (
-    test_time_driver_check_for_energy_and_dynamics,
-    test_time_driver_drive_exception,
-    test_time_driver_euler_evolver_nodriver,
-    test_time_driver_nodamping,
-    test_time_driver_noevolver_driver,
-    test_time_driver_noevolver_nodriver,
-    test_time_driver_noevolver_nodriver_finite_temperature,
-    test_time_driver_noprecession,
-    test_time_driver_output_files,
-    test_time_driver_rungekutta_evolver_nodriver,
-    test_time_driver_therm_heun_evolver_nodriver,
-    test_time_driver_theta_evolver_nodriver,
-    test_time_driver_wrong_evolver,
-    time_driver_case,
-)
-from .uniaxialanisotropy import (
-    test_uniaxial_anisotropy_dict_vector,
-    test_uniaxial_anisotropy_field_dict,
-    test_uniaxial_anisotropy_field_field,
-    test_uniaxial_anisotropy_field_vector,
-    test_uniaxial_anisotropy_higher_order_scalar_vector,
-    test_uniaxial_anisotropy_scalar_field,
-    test_uniaxial_anisotropy_scalar_vector,
-    uniaxial_anisotropy_case,
-)
-from .zeeman import (
-    test_zeeman_dict,
-    test_zeeman_field,
-    test_zeeman_time_dict,
-    test_zeeman_time_field,
-    test_zeeman_time_vector,
-    test_zeeman_vector,
-    zeeman_case,
-)
-from .zhangli import (
-    test_zhang_li_dict_scalar_u,
-    test_zhang_li_dict_vector_u,
-    test_zhang_li_field_scalar_u,
-    test_zhang_li_field_vector_u,
-    test_zhang_li_scalar_u,
-    test_zhang_li_time_func_scalar_u,
-    test_zhang_li_time_tcl_scalar_u,
-    test_zhang_li_vector_u,
-    zhang_li_case,
+from importlib import import_module
+
+_MODULES = (
+    "compute",
+    "cubicanisotropy",
+    "damping",
+    "demag",
+    "dirname",
+    "dmi",
+    "dynamics",
+    "energy",
+    "exchange",
+    "fixedsubregions",
+    "hysteresisdriver",
+    "info_file",
+    "mesh",
+    "mindriver",
+    "multiple_drives",
+    "outputformat",
+    "outputstep",
+    "precession",
+    "relaxdriver",
+    "rkky",
+    "schedule",
+    "skyrmion",
+    "slonczewski",
+    "stdprob3",
+    "stdprob4",
+    "stdprob5",
+    "threads",
+    "timedriver",
+    "uniaxialanisotropy",
+    "zeeman",
+    "zhangli",
 )
 
-__all__ = [
-    "compute_case",
-    "test_compute_energy",
-    "test_compute_energy_density",
-    "test_compute_effective_field",
-    "test_compute_invalid_func",
-    "test_compute_dmi",
-    "test_compute_slonczewski",
-    "test_compute_zhang_li",
-    "cubic_anisotropy_case",
-    "test_cubic_anisotropy_scalar_vector_vector",
-    "test_cubic_anisotropy_field_vector_vector",
-    "test_cubic_anisotropy_field_field_field",
-    "test_cubic_anisotropy_dict_vector_vector",
-    "damping_case",
-    "test_damping_scalar",
-    "test_damping_dict",
-    "test_damping_field",
-    "demag_case",
-    "test_demag_demag",
-    "test_demag_demag_asymptotic_radius",
-    "test_demag_demag_1_pbc",
-    "test_demag_demag_2_pbc",
-    "test_demag_demag_3_pbc",
-    "test_dirname",
-    "dmi_case",
-    "test_dmi_scalar",
-    "test_dmi_dict",
-    "test_dmi_crystalclass",
-    "test_dmi_crystalclass_init",
-    "dynamics_case",
-    "test_dynamics_scalar_scalar",
-    "test_dynamics_scalar_dict",
-    "test_dynamics_field_field",
-    "energy_case",
-    "test_energy_exchange_zeeman",
-    "test_energy_exchange_uniaxialanisotropy",
-    "test_energy_exchange_cubicanisotropy",
-    "test_energy_exchange_dmi_zeeman",
-    "test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag",
-    "test_energy_zeeman_zeeman",
-    "exchange_case",
-    "test_exchange_scalar",
-    "test_exchange_dict",
-    "test_exchange_field",
-    "fixed_subregions_case",
-    "test_fixed_subregions_fixed_subregions",
-    "Ms",
-    "system",
-    "test_simple_hysteresis_loop",
-    "test_stepped_hysteresis_loop",
-    "test_hysteresis_check_for_energy",
-    "test_info_file",
-    "mesh_case",
-    "test_mesh_single_nopbc",
-    "test_mesh_multi_nopbc",
-    "test_mesh_single_pbc",
-    "test_mesh_multi_pbc",
-    "min_driver_case",
-    "test_min_driver_noevolver_nodriver",
-    "test_min_driver_evolver_nodriver",
-    "test_min_driver_noevolver_driver",
-    "test_min_driver_evolver_driver",
-    "test_min_driver_output_files",
-    "test_min_driver_wrong_evolver",
-    "test_min_driver_check_for_energy",
-    "test_multiple_drives",
-    "test_multiple_drives_compute",
-    "test_format",
-    "test_outputstep",
-    "precession_case",
-    "test_precession_scalar",
-    "test_precession_dict",
-    "test_precession_field",
-    "test_relaxdriver",
-    "test_relax_check_for_energy",
-    "rkky_case",
-    "test_rkky_scalar",
-    "test_schedule",
-    "test_skyrmion",
-    "slonczewski_case",
-    "test_slonczewski_single_values",
-    "test_slonczewski_single_values_finite_temperature",
-    "test_slonczewski_dict_values",
-    "test_slonczewski_field_values",
-    "test_stdprob3",
-    "test_stdprob4",
-    "test_stdprob5",
-    "threads_case",
-    "test_threads_threads",
-    "time_driver_case",
-    "test_time_driver_noevolver_nodriver",
-    "test_time_driver_rungekutta_evolver_nodriver",
-    "test_time_driver_euler_evolver_nodriver",
-    "test_time_driver_theta_evolver_nodriver",
-    "test_time_driver_therm_heun_evolver_nodriver",
-    "test_time_driver_noevolver_nodriver_finite_temperature",
-    "test_time_driver_noevolver_driver",
-    "test_time_driver_noprecession",
-    "test_time_driver_nodamping",
-    "test_time_driver_output_files",
-    "test_time_driver_drive_exception",
-    "test_time_driver_wrong_evolver",
-    "test_time_driver_check_for_energy_and_dynamics",
-    "uniaxial_anisotropy_case",
-    "test_uniaxial_anisotropy_scalar_vector",
-    "test_uniaxial_anisotropy_field_vector",
-    "test_uniaxial_anisotropy_scalar_field",
-    "test_uniaxial_anisotropy_field_field",
-    "test_uniaxial_anisotropy_dict_vector",
-    "test_uniaxial_anisotropy_field_dict",
-    "test_uniaxial_anisotropy_higher_order_scalar_vector",
-    "zeeman_case",
-    "test_zeeman_vector",
-    "test_zeeman_time_vector",
-    "test_zeeman_dict",
-    "test_zeeman_time_dict",
-    "test_zeeman_field",
-    "test_zeeman_time_field",
-    "zhang_li_case",
-    "test_zhang_li_scalar_u",
-    "test_zhang_li_time_func_scalar_u",
-    "test_zhang_li_time_tcl_scalar_u",
-    "test_zhang_li_dict_scalar_u",
-    "test_zhang_li_dict_vector_u",
-    "test_zhang_li_field_scalar_u",
-    "test_zhang_li_field_vector_u",
-    "test_zhang_li_vector_u",
-]
+
+def _is_test_or_fixture(name, obj):
+    return name.startswith("test_") or hasattr(obj, "_fixture_function_marker")
+
+
+for _module_name in _MODULES:
+    _module = import_module(f"{__name__}.{_module_name}")
+    globals().update(
+        {
+            name: obj
+            for name, obj in vars(_module).items()
+            if _is_test_or_fixture(name, obj)
+        }
+    )
+    globals().pop(_module_name, None)
+
+del import_module, _is_test_or_fixture, _module, _module_name

--- a/micromagnetictests/calculatortests/__init__.py
+++ b/micromagnetictests/calculatortests/__init__.py
@@ -1,42 +1,291 @@
-"""Calculator tests"""
+"""Calculator tests."""
 
-from .compute import TestCompute as TestCompute
-from .cubicanisotropy import TestCubicAnisotropy as TestCubicAnisotropy
-from .damping import TestDamping as TestDamping
-from .demag import TestDemag as TestDemag
-from .dirname import test_dirname as test_dirname
-from .dmi import TestDMI as TestDMI
-from .dynamics import TestDynamics as TestDynamics
-from .energy import TestEnergy as TestEnergy
-from .exchange import TestExchange as TestExchange
-from .fixedsubregions import TestFixedSubregions as TestFixedSubregions
-from .hysteresisdriver import Ms as Ms
-from .hysteresisdriver import system as system
-from .hysteresisdriver import (
-    test_hysteresis_check_for_energy as test_hysteresis_check_for_energy,
+from .compute import (
+    compute_case,
+    test_compute_dmi,
+    test_compute_effective_field,
+    test_compute_energy,
+    test_compute_energy_density,
+    test_compute_invalid_func,
+    test_compute_slonczewski,
+    test_compute_zhang_li,
 )
-from .hysteresisdriver import test_simple_hysteresis_loop as test_simple_hysteresis_loop
-from .hysteresisdriver import (
-    test_stepped_hysteresis_loop as test_stepped_hysteresis_loop,
+from .cubicanisotropy import (
+    cubic_anisotropy_case,
+    test_cubic_anisotropy_dict_vector_vector,
+    test_cubic_anisotropy_field_field_field,
+    test_cubic_anisotropy_field_vector_vector,
+    test_cubic_anisotropy_scalar_vector_vector,
 )
-from .info_file import test_info_file as test_info_file
-from .mesh import TestMesh as TestMesh
-from .mindriver import TestMinDriver as TestMinDriver
-from .multiple_drives import test_multiple_drives as test_multiple_drives
-from .outputformat import test_format as test_format
-from .outputstep import test_outputstep as test_outputstep
-from .precession import TestPrecession as TestPrecession
-from .relaxdriver import test_relax_check_for_energy as test_relax_check_for_energy
-from .relaxdriver import test_relaxdriver as test_relaxdriver
-from .rkky import TestRKKY as TestRKKY
-from .schedule import test_schedule as test_schedule
-from .skyrmion import test_skyrmion as test_skyrmion
-from .slonczewski import TestSlonczewski as TestSlonczewski
-from .stdprob3 import test_stdprob3 as test_stdprob3
-from .stdprob4 import test_stdprob4 as test_stdprob4
-from .stdprob5 import test_stdprob5 as test_stdprob5
-from .threads import TestThreads as TestThreads
-from .timedriver import TestTimeDriver as TestTimeDriver
-from .uniaxialanisotropy import TestUniaxialAnisotropy as TestUniaxialAnisotropy
-from .zeeman import TestZeeman as TestZeeman
-from .zhangli import TestZhangLi as TestZhangLi
+from .damping import (
+    damping_case,
+    test_damping_dict,
+    test_damping_field,
+    test_damping_scalar,
+)
+from .demag import (
+    demag_case,
+    test_demag_demag,
+    test_demag_demag_1_pbc,
+    test_demag_demag_2_pbc,
+    test_demag_demag_3_pbc,
+    test_demag_demag_asymptotic_radius,
+)
+from .dirname import test_dirname
+from .dmi import (
+    dmi_case,
+    test_dmi_crystalclass,
+    test_dmi_crystalclass_init,
+    test_dmi_dict,
+    test_dmi_scalar,
+)
+from .dynamics import (
+    dynamics_case,
+    test_dynamics_field_field,
+    test_dynamics_scalar_dict,
+    test_dynamics_scalar_scalar,
+)
+from .energy import (
+    energy_case,
+    test_energy_exchange_cubicanisotropy,
+    test_energy_exchange_dmi_zeeman,
+    test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag,
+    test_energy_exchange_uniaxialanisotropy,
+    test_energy_exchange_zeeman,
+    test_energy_zeeman_zeeman,
+)
+from .exchange import (
+    exchange_case,
+    test_exchange_dict,
+    test_exchange_field,
+    test_exchange_scalar,
+)
+from .fixedsubregions import (
+    fixed_subregions_case,
+    test_fixed_subregions_fixed_subregions,
+)
+from .hysteresisdriver import (
+    Ms,
+    system,
+    test_hysteresis_check_for_energy,
+    test_simple_hysteresis_loop,
+    test_stepped_hysteresis_loop,
+)
+from .info_file import test_info_file
+from .mesh import (
+    mesh_case,
+    test_mesh_multi_nopbc,
+    test_mesh_multi_pbc,
+    test_mesh_single_nopbc,
+    test_mesh_single_pbc,
+)
+from .mindriver import (
+    min_driver_case,
+    test_min_driver_check_for_energy,
+    test_min_driver_evolver_driver,
+    test_min_driver_evolver_nodriver,
+    test_min_driver_noevolver_driver,
+    test_min_driver_noevolver_nodriver,
+    test_min_driver_output_files,
+    test_min_driver_wrong_evolver,
+)
+from .multiple_drives import test_multiple_drives, test_multiple_drives_compute
+from .outputformat import test_format
+from .outputstep import test_outputstep
+from .precession import (
+    precession_case,
+    test_precession_dict,
+    test_precession_field,
+    test_precession_scalar,
+)
+from .relaxdriver import test_relax_check_for_energy, test_relaxdriver
+from .rkky import rkky_case, test_rkky_scalar
+from .schedule import test_schedule
+from .skyrmion import test_skyrmion
+from .slonczewski import (
+    slonczewski_case,
+    test_slonczewski_dict_values,
+    test_slonczewski_field_values,
+    test_slonczewski_single_values,
+    test_slonczewski_single_values_finite_temperature,
+)
+from .stdprob3 import test_stdprob3
+from .stdprob4 import test_stdprob4
+from .stdprob5 import test_stdprob5
+from .threads import test_threads_threads, threads_case
+from .timedriver import (
+    test_time_driver_check_for_energy_and_dynamics,
+    test_time_driver_drive_exception,
+    test_time_driver_euler_evolver_nodriver,
+    test_time_driver_nodamping,
+    test_time_driver_noevolver_driver,
+    test_time_driver_noevolver_nodriver,
+    test_time_driver_noevolver_nodriver_finite_temperature,
+    test_time_driver_noprecession,
+    test_time_driver_output_files,
+    test_time_driver_rungekutta_evolver_nodriver,
+    test_time_driver_therm_heun_evolver_nodriver,
+    test_time_driver_theta_evolver_nodriver,
+    test_time_driver_wrong_evolver,
+    time_driver_case,
+)
+from .uniaxialanisotropy import (
+    test_uniaxial_anisotropy_dict_vector,
+    test_uniaxial_anisotropy_field_dict,
+    test_uniaxial_anisotropy_field_field,
+    test_uniaxial_anisotropy_field_vector,
+    test_uniaxial_anisotropy_higher_order_scalar_vector,
+    test_uniaxial_anisotropy_scalar_field,
+    test_uniaxial_anisotropy_scalar_vector,
+    uniaxial_anisotropy_case,
+)
+from .zeeman import (
+    test_zeeman_dict,
+    test_zeeman_field,
+    test_zeeman_time_dict,
+    test_zeeman_time_field,
+    test_zeeman_time_vector,
+    test_zeeman_vector,
+    zeeman_case,
+)
+from .zhangli import (
+    test_zhang_li_dict_scalar_u,
+    test_zhang_li_dict_vector_u,
+    test_zhang_li_field_scalar_u,
+    test_zhang_li_field_vector_u,
+    test_zhang_li_scalar_u,
+    test_zhang_li_time_func_scalar_u,
+    test_zhang_li_time_tcl_scalar_u,
+    test_zhang_li_vector_u,
+    zhang_li_case,
+)
+
+__all__ = [
+    "compute_case",
+    "test_compute_energy",
+    "test_compute_energy_density",
+    "test_compute_effective_field",
+    "test_compute_invalid_func",
+    "test_compute_dmi",
+    "test_compute_slonczewski",
+    "test_compute_zhang_li",
+    "cubic_anisotropy_case",
+    "test_cubic_anisotropy_scalar_vector_vector",
+    "test_cubic_anisotropy_field_vector_vector",
+    "test_cubic_anisotropy_field_field_field",
+    "test_cubic_anisotropy_dict_vector_vector",
+    "damping_case",
+    "test_damping_scalar",
+    "test_damping_dict",
+    "test_damping_field",
+    "demag_case",
+    "test_demag_demag",
+    "test_demag_demag_asymptotic_radius",
+    "test_demag_demag_1_pbc",
+    "test_demag_demag_2_pbc",
+    "test_demag_demag_3_pbc",
+    "test_dirname",
+    "dmi_case",
+    "test_dmi_scalar",
+    "test_dmi_dict",
+    "test_dmi_crystalclass",
+    "test_dmi_crystalclass_init",
+    "dynamics_case",
+    "test_dynamics_scalar_scalar",
+    "test_dynamics_scalar_dict",
+    "test_dynamics_field_field",
+    "energy_case",
+    "test_energy_exchange_zeeman",
+    "test_energy_exchange_uniaxialanisotropy",
+    "test_energy_exchange_cubicanisotropy",
+    "test_energy_exchange_dmi_zeeman",
+    "test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag",
+    "test_energy_zeeman_zeeman",
+    "exchange_case",
+    "test_exchange_scalar",
+    "test_exchange_dict",
+    "test_exchange_field",
+    "fixed_subregions_case",
+    "test_fixed_subregions_fixed_subregions",
+    "Ms",
+    "system",
+    "test_simple_hysteresis_loop",
+    "test_stepped_hysteresis_loop",
+    "test_hysteresis_check_for_energy",
+    "test_info_file",
+    "mesh_case",
+    "test_mesh_single_nopbc",
+    "test_mesh_multi_nopbc",
+    "test_mesh_single_pbc",
+    "test_mesh_multi_pbc",
+    "min_driver_case",
+    "test_min_driver_noevolver_nodriver",
+    "test_min_driver_evolver_nodriver",
+    "test_min_driver_noevolver_driver",
+    "test_min_driver_evolver_driver",
+    "test_min_driver_output_files",
+    "test_min_driver_wrong_evolver",
+    "test_min_driver_check_for_energy",
+    "test_multiple_drives",
+    "test_multiple_drives_compute",
+    "test_format",
+    "test_outputstep",
+    "precession_case",
+    "test_precession_scalar",
+    "test_precession_dict",
+    "test_precession_field",
+    "test_relaxdriver",
+    "test_relax_check_for_energy",
+    "rkky_case",
+    "test_rkky_scalar",
+    "test_schedule",
+    "test_skyrmion",
+    "slonczewski_case",
+    "test_slonczewski_single_values",
+    "test_slonczewski_single_values_finite_temperature",
+    "test_slonczewski_dict_values",
+    "test_slonczewski_field_values",
+    "test_stdprob3",
+    "test_stdprob4",
+    "test_stdprob5",
+    "threads_case",
+    "test_threads_threads",
+    "time_driver_case",
+    "test_time_driver_noevolver_nodriver",
+    "test_time_driver_rungekutta_evolver_nodriver",
+    "test_time_driver_euler_evolver_nodriver",
+    "test_time_driver_theta_evolver_nodriver",
+    "test_time_driver_therm_heun_evolver_nodriver",
+    "test_time_driver_noevolver_nodriver_finite_temperature",
+    "test_time_driver_noevolver_driver",
+    "test_time_driver_noprecession",
+    "test_time_driver_nodamping",
+    "test_time_driver_output_files",
+    "test_time_driver_drive_exception",
+    "test_time_driver_wrong_evolver",
+    "test_time_driver_check_for_energy_and_dynamics",
+    "uniaxial_anisotropy_case",
+    "test_uniaxial_anisotropy_scalar_vector",
+    "test_uniaxial_anisotropy_field_vector",
+    "test_uniaxial_anisotropy_scalar_field",
+    "test_uniaxial_anisotropy_field_field",
+    "test_uniaxial_anisotropy_dict_vector",
+    "test_uniaxial_anisotropy_field_dict",
+    "test_uniaxial_anisotropy_higher_order_scalar_vector",
+    "zeeman_case",
+    "test_zeeman_vector",
+    "test_zeeman_time_vector",
+    "test_zeeman_dict",
+    "test_zeeman_time_dict",
+    "test_zeeman_field",
+    "test_zeeman_time_field",
+    "zhang_li_case",
+    "test_zhang_li_scalar_u",
+    "test_zhang_li_time_func_scalar_u",
+    "test_zhang_li_time_tcl_scalar_u",
+    "test_zhang_li_dict_scalar_u",
+    "test_zhang_li_dict_vector_u",
+    "test_zhang_li_field_scalar_u",
+    "test_zhang_li_field_vector_u",
+    "test_zhang_li_vector_u",
+]

--- a/micromagnetictests/calculatortests/compute.py
+++ b/micromagnetictests/calculatortests/compute.py
@@ -36,52 +36,58 @@ def compute_case(calculator):
 
 
 def test_compute_energy(compute_case):
-    self = compute_case
-    for term in self.system.energy:
-        assert isinstance(self.calculator.compute(term.energy, self.system), float)
+    for term in compute_case.system.energy:
+        assert isinstance(
+            compute_case.calculator.compute(term.energy, compute_case.system), float
+        )
     assert isinstance(
-        self.calculator.compute(self.system.energy.energy, self.system), float
+        compute_case.calculator.compute(
+            compute_case.system.energy.energy, compute_case.system
+        ),
+        float,
     )
-    self.calculator.delete(self.system)
+    compute_case.calculator.delete(compute_case.system)
 
 
 def test_compute_energy_density(compute_case):
-    self = compute_case
-    for term in self.system.energy:
-        e_density = self.calculator.compute(term.density, self.system)
+    for term in compute_case.system.energy:
+        e_density = compute_case.calculator.compute(term.density, compute_case.system)
         assert isinstance(e_density, df.Field)
-        assert e_density.mesh.subregions == self.subregions
-    e_density = self.calculator.compute(self.system.energy.density, self.system)
+        assert e_density.mesh.subregions == compute_case.subregions
+    e_density = compute_case.calculator.compute(
+        compute_case.system.energy.density, compute_case.system
+    )
     assert isinstance(e_density, df.Field)
-    assert e_density.mesh.subregions == self.subregions
-    self.calculator.delete(self.system)
+    assert e_density.mesh.subregions == compute_case.subregions
+    compute_case.calculator.delete(compute_case.system)
 
 
 def test_compute_effective_field(compute_case):
-    self = compute_case
-    for term in self.system.energy:
-        effective_field = self.calculator.compute(term.effective_field, self.system)
+    for term in compute_case.system.energy:
+        effective_field = compute_case.calculator.compute(
+            term.effective_field, compute_case.system
+        )
         assert isinstance(effective_field, df.Field)
-        assert effective_field.mesh.subregions == self.subregions
-    effective_field = self.calculator.compute(
-        self.system.energy.effective_field, self.system
+        assert effective_field.mesh.subregions == compute_case.subregions
+    effective_field = compute_case.calculator.compute(
+        compute_case.system.energy.effective_field, compute_case.system
     )
     assert isinstance(effective_field, df.Field)
-    assert effective_field.mesh.subregions == self.subregions
-    self.calculator.delete(self.system)
+    assert effective_field.mesh.subregions == compute_case.subregions
+    compute_case.calculator.delete(compute_case.system)
 
 
 def test_compute_invalid_func(compute_case):
-    self = compute_case
     with pytest.raises(ValueError):
-        self.calculator.compute(self.system.energy.__len__, self.system)
+        compute_case.calculator.compute(
+            compute_case.system.energy.__len__, compute_case.system
+        )
 
 
 def test_compute_dmi(compute_case):
-    self = compute_case
     if sys.platform != "win32":
-        self.system.energy += mm.DMI(D=5e-3, crystalclass="T")
-        term = self.system.energy.dmi
+        compute_case.system.energy += mm.DMI(D=5e-3, crystalclass="T")
+        term = compute_case.system.energy.dmi
         for crystalclass in [
             "T",
             "Cnv_x",
@@ -92,32 +98,47 @@ def test_compute_dmi(compute_case):
             "D2d_z",
         ]:
             term.crystalclass = crystalclass
-            assert isinstance(self.calculator.compute(term.energy, self.system), float)
-            e_density = self.calculator.compute(term.density, self.system)
+            assert isinstance(
+                compute_case.calculator.compute(term.energy, compute_case.system), float
+            )
+            e_density = compute_case.calculator.compute(
+                term.density, compute_case.system
+            )
             assert isinstance(e_density, df.Field)
-            assert e_density.mesh.subregions == self.subregions
-            effective_field = self.calculator.compute(term.effective_field, self.system)
+            assert e_density.mesh.subregions == compute_case.subregions
+            effective_field = compute_case.calculator.compute(
+                term.effective_field, compute_case.system
+            )
             assert isinstance(effective_field, df.Field)
-            assert effective_field.mesh.subregions == self.subregions
+            assert effective_field.mesh.subregions == compute_case.subregions
         assert isinstance(
-            self.calculator.compute(self.system.energy.energy, self.system), float
+            compute_case.calculator.compute(
+                compute_case.system.energy.energy, compute_case.system
+            ),
+            float,
         )
-        self.calculator.delete(self.system)
+        compute_case.calculator.delete(compute_case.system)
 
 
 def test_compute_slonczewski(compute_case):
-    self = compute_case
-    self.system.dynamics = mm.Slonczewski(J=7.5e12, mp=(1, 0, 0), P=0.4, Lambda=2)
-    assert isinstance(
-        self.calculator.compute(self.system.energy.energy, self.system), float
+    compute_case.system.dynamics = mm.Slonczewski(
+        J=7.5e12, mp=(1, 0, 0), P=0.4, Lambda=2
     )
-    self.calculator.delete(self.system)
+    assert isinstance(
+        compute_case.calculator.compute(
+            compute_case.system.energy.energy, compute_case.system
+        ),
+        float,
+    )
+    compute_case.calculator.delete(compute_case.system)
 
 
 def test_compute_zhang_li(compute_case):
-    self = compute_case
-    self.system.dynamics = mm.ZhangLi(beta=0.01, u=5e6)
+    compute_case.system.dynamics = mm.ZhangLi(beta=0.01, u=5e6)
     assert isinstance(
-        self.calculator.compute(self.system.energy.energy, self.system), float
+        compute_case.calculator.compute(
+            compute_case.system.energy.energy, compute_case.system
+        ),
+        float,
     )
-    self.calculator.delete(self.system)
+    compute_case.calculator.delete(compute_case.system)

--- a/micromagnetictests/calculatortests/compute.py
+++ b/micromagnetictests/calculatortests/compute.py
@@ -1,112 +1,123 @@
 import sys
+from types import SimpleNamespace
 
 import discretisedfield as df
 import micromagneticmodel as mm
 import pytest
 
 
-class TestCompute:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def compute_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    name = "compute_tests"
+    p1 = (0, 0, 0)
+    p2 = (10e-9, 2e-9, 2e-9)
+    cell = (2e-9, 2e-9, 2e-9)
+    region = df.Region(p1=p1, p2=p2)
+    subregions = {
+        "a": df.Region(p1=(0, 0, 0), p2=(6e-9, 2e-9, 2e-9)),
+        "b": df.Region(p1=(6e-9, 0, 0), p2=(10e-9, 2e-9, 2e-9)),
+    }
+    mesh = df.Mesh(region=region, cell=cell, subregions=subregions)
+    case.subregions = subregions
+    case.system = mm.System(name=name)
+    case.system.energy = (
+        mm.Exchange(A=1e-12)
+        + mm.Demag()
+        + mm.Zeeman(H=(8e6, 0, 0))
+        + mm.UniaxialAnisotropy(K=1e4, u=(0, 0, 1))
+        + mm.CubicAnisotropy(K=1e3, u1=(1, 0, 0), u2=(0, 1, 0))
+    )
 
-    def setup_method(self):
-        name = "compute_tests"
-        p1 = (0, 0, 0)
-        p2 = (10e-9, 2e-9, 2e-9)
-        cell = (2e-9, 2e-9, 2e-9)
-        region = df.Region(p1=p1, p2=p2)
-        subregions = {
-            "a": df.Region(p1=(0, 0, 0), p2=(6e-9, 2e-9, 2e-9)),
-            "b": df.Region(p1=(6e-9, 0, 0), p2=(10e-9, 2e-9, 2e-9)),
-        }
-        mesh = df.Mesh(region=region, cell=cell, subregions=subregions)
-        self.subregions = subregions
-        self.system = mm.System(name=name)
-        self.system.energy = (
-            mm.Exchange(A=1e-12)
-            + mm.Demag()
-            + mm.Zeeman(H=(8e6, 0, 0))
-            + mm.UniaxialAnisotropy(K=1e4, u=(0, 0, 1))
-            + mm.CubicAnisotropy(K=1e3, u1=(1, 0, 0), u2=(0, 1, 0))
-        )
+    case.system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=8e6)
 
-        self.system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=8e6)
+    return case
 
-    def test_energy(self):
-        for term in self.system.energy:
+
+def test_compute_energy(compute_case):
+    self = compute_case
+    for term in self.system.energy:
+        assert isinstance(self.calculator.compute(term.energy, self.system), float)
+    assert isinstance(
+        self.calculator.compute(self.system.energy.energy, self.system), float
+    )
+    self.calculator.delete(self.system)
+
+
+def test_compute_energy_density(compute_case):
+    self = compute_case
+    for term in self.system.energy:
+        e_density = self.calculator.compute(term.density, self.system)
+        assert isinstance(e_density, df.Field)
+        assert e_density.mesh.subregions == self.subregions
+    e_density = self.calculator.compute(self.system.energy.density, self.system)
+    assert isinstance(e_density, df.Field)
+    assert e_density.mesh.subregions == self.subregions
+    self.calculator.delete(self.system)
+
+
+def test_compute_effective_field(compute_case):
+    self = compute_case
+    for term in self.system.energy:
+        effective_field = self.calculator.compute(term.effective_field, self.system)
+        assert isinstance(effective_field, df.Field)
+        assert effective_field.mesh.subregions == self.subregions
+    effective_field = self.calculator.compute(
+        self.system.energy.effective_field, self.system
+    )
+    assert isinstance(effective_field, df.Field)
+    assert effective_field.mesh.subregions == self.subregions
+    self.calculator.delete(self.system)
+
+
+def test_compute_invalid_func(compute_case):
+    self = compute_case
+    with pytest.raises(ValueError):
+        self.calculator.compute(self.system.energy.__len__, self.system)
+
+
+def test_compute_dmi(compute_case):
+    self = compute_case
+    if sys.platform != "win32":
+        self.system.energy += mm.DMI(D=5e-3, crystalclass="T")
+        term = self.system.energy.dmi
+        for crystalclass in [
+            "T",
+            "Cnv_x",
+            "Cnv_y",
+            "Cnv_z",
+            "D2d_x",
+            "D2d_y",
+            "D2d_z",
+        ]:
+            term.crystalclass = crystalclass
             assert isinstance(self.calculator.compute(term.energy, self.system), float)
-        assert isinstance(
-            self.calculator.compute(self.system.energy.energy, self.system), float
-        )
-        self.calculator.delete(self.system)
-
-    def test_energy_density(self):
-        for term in self.system.energy:
             e_density = self.calculator.compute(term.density, self.system)
             assert isinstance(e_density, df.Field)
             assert e_density.mesh.subregions == self.subregions
-        e_density = self.calculator.compute(self.system.energy.density, self.system)
-        assert isinstance(e_density, df.Field)
-        assert e_density.mesh.subregions == self.subregions
-        self.calculator.delete(self.system)
-
-    def test_effective_field(self):
-        for term in self.system.energy:
             effective_field = self.calculator.compute(term.effective_field, self.system)
             assert isinstance(effective_field, df.Field)
             assert effective_field.mesh.subregions == self.subregions
-        effective_field = self.calculator.compute(
-            self.system.energy.effective_field, self.system
-        )
-        assert isinstance(effective_field, df.Field)
-        assert effective_field.mesh.subregions == self.subregions
-        self.calculator.delete(self.system)
-
-    def test_invalid_func(self):
-        with pytest.raises(ValueError):
-            self.calculator.compute(self.system.energy.__len__, self.system)
-
-    def test_dmi(self):
-        if sys.platform != "win32":
-            self.system.energy += mm.DMI(D=5e-3, crystalclass="T")
-            term = self.system.energy.dmi
-            for crystalclass in [
-                "T",
-                "Cnv_x",
-                "Cnv_y",
-                "Cnv_z",
-                "D2d_x",
-                "D2d_y",
-                "D2d_z",
-            ]:
-                term.crystalclass = crystalclass
-                assert isinstance(
-                    self.calculator.compute(term.energy, self.system), float
-                )
-                e_density = self.calculator.compute(term.density, self.system)
-                assert isinstance(e_density, df.Field)
-                assert e_density.mesh.subregions == self.subregions
-                effective_field = self.calculator.compute(
-                    term.effective_field, self.system
-                )
-                assert isinstance(effective_field, df.Field)
-                assert effective_field.mesh.subregions == self.subregions
-            assert isinstance(
-                self.calculator.compute(self.system.energy.energy, self.system), float
-            )
-            self.calculator.delete(self.system)
-
-    def test_slonczewski(self):
-        self.system.dynamics = mm.Slonczewski(J=7.5e12, mp=(1, 0, 0), P=0.4, Lambda=2)
         assert isinstance(
             self.calculator.compute(self.system.energy.energy, self.system), float
         )
         self.calculator.delete(self.system)
 
-    def test_zhang_li(self):
-        self.system.dynamics = mm.ZhangLi(beta=0.01, u=5e6)
-        assert isinstance(
-            self.calculator.compute(self.system.energy.energy, self.system), float
-        )
-        self.calculator.delete(self.system)
+
+def test_compute_slonczewski(compute_case):
+    self = compute_case
+    self.system.dynamics = mm.Slonczewski(J=7.5e12, mp=(1, 0, 0), P=0.4, Lambda=2)
+    assert isinstance(
+        self.calculator.compute(self.system.energy.energy, self.system), float
+    )
+    self.calculator.delete(self.system)
+
+
+def test_compute_zhang_li(compute_case):
+    self = compute_case
+    self.system.dynamics = mm.ZhangLi(beta=0.01, u=5e6)
+    assert isinstance(
+        self.calculator.compute(self.system.energy.energy, self.system), float
+    )
+    self.calculator.delete(self.system)

--- a/micromagnetictests/calculatortests/cubicanisotropy.py
+++ b/micromagnetictests/calculatortests/cubicanisotropy.py
@@ -23,10 +23,9 @@ def cubic_anisotropy_case(calculator):
 
 
 def test_cubic_anisotropy_scalar_vector_vector(cubic_anisotropy_case):
-    self = cubic_anisotropy_case
     name = "cubicanisotropy_scalar_vector_vector"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=cubic_anisotropy_case.region, cell=cubic_anisotropy_case.cell)
 
     K = 1e5
     u1 = (0, 0, 1)
@@ -45,7 +44,7 @@ def test_cubic_anisotropy_scalar_vector_vector(cubic_anisotropy_case):
 
     system.m = df.Field(mesh, nvdim=3, value=m_fun, norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = cubic_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-1e-9, 2e-9, 2e-9))
@@ -54,14 +53,13 @@ def test_cubic_anisotropy_scalar_vector_vector(cubic_anisotropy_case):
     value = system.m((1e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    cubic_anisotropy_case.calculator.delete(system)
 
 
 def test_cubic_anisotropy_field_vector_vector(cubic_anisotropy_case):
-    self = cubic_anisotropy_case
     name = "cubicanisotropy_field_vector_vector"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=cubic_anisotropy_case.region, cell=cubic_anisotropy_case.cell)
 
     def K_fun(pos):
         x, y, z = pos
@@ -79,7 +77,7 @@ def test_cubic_anisotropy_field_vector_vector(cubic_anisotropy_case):
     system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = cubic_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, 1e-9, 1e-9))
@@ -88,14 +86,13 @@ def test_cubic_anisotropy_field_vector_vector(cubic_anisotropy_case):
     value = system.m((2e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    cubic_anisotropy_case.calculator.delete(system)
 
 
 def test_cubic_anisotropy_field_field_field(cubic_anisotropy_case):
-    self = cubic_anisotropy_case
     name = "cubicanisotropy_field_field_field"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=cubic_anisotropy_case.region, cell=cubic_anisotropy_case.cell)
 
     def K_fun(pos):
         x, y, z = pos
@@ -127,7 +124,7 @@ def test_cubic_anisotropy_field_field_field(cubic_anisotropy_case):
     system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = cubic_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((0, 0, 0))
@@ -139,14 +136,17 @@ def test_cubic_anisotropy_field_field_field(cubic_anisotropy_case):
     value = system.m((-3e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    cubic_anisotropy_case.calculator.delete(system)
 
 
 def test_cubic_anisotropy_dict_vector_vector(cubic_anisotropy_case):
-    self = cubic_anisotropy_case
     name = "cubicanisotropy_dict_vector_vector"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=cubic_anisotropy_case.region,
+        cell=cubic_anisotropy_case.cell,
+        subregions=cubic_anisotropy_case.subregions,
+    )
 
     K = {"r1": 0, "r2": 1e5}
     u1 = (0, 0, 1)
@@ -157,7 +157,7 @@ def test_cubic_anisotropy_dict_vector_vector(cubic_anisotropy_case):
     system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = cubic_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, 1e-9, 1e-9))
@@ -166,4 +166,4 @@ def test_cubic_anisotropy_dict_vector_vector(cubic_anisotropy_case):
     value = system.m((2e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    cubic_anisotropy_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/cubicanisotropy.py
+++ b/micromagnetictests/calculatortests/cubicanisotropy.py
@@ -1,159 +1,169 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestCubicAnisotropy:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def cubic_anisotropy_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-7e-9, 0, 0)
+    p2 = (7e-9, 5e-9, 4e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 2e-9)
+    case.subregions = {
+        "r1": df.Region(p1=(-7e-9, 0, 0), p2=(0, 5e-9, 4e-9)),
+        "r2": df.Region(p1=(0, 0, 0), p2=(7e-9, 5e-9, 4e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-7e-9, 0, 0)
-        p2 = (7e-9, 5e-9, 4e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 2e-9)
-        self.subregions = {
-            "r1": df.Region(p1=(-7e-9, 0, 0), p2=(0, 5e-9, 4e-9)),
-            "r2": df.Region(p1=(0, 0, 0), p2=(7e-9, 5e-9, 4e-9)),
-        }
+    return case
 
-    def test_scalar_vector_vector(self):
-        name = "cubicanisotropy_scalar_vector_vector"
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+def test_cubic_anisotropy_scalar_vector_vector(cubic_anisotropy_case):
+    self = cubic_anisotropy_case
+    name = "cubicanisotropy_scalar_vector_vector"
 
-        K = 1e5
-        u1 = (0, 0, 1)
-        u2 = (0, 1, 0)
-        Ms = 1e6
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        system = mm.System(name=name)
-        system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
+    K = 1e5
+    u1 = (0, 0, 1)
+    u2 = (0, 1, 0)
+    Ms = 1e6
 
-        def m_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (0, 0.2, 1)
-            else:
-                return (0, 1, 0.2)
+    system = mm.System(name=name)
+    system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
 
-        system.m = df.Field(mesh, nvdim=3, value=m_fun, norm=Ms)
+    def m_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (0, 0.2, 1)
+        else:
+            return (0, 1, 0.2)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system.m = df.Field(mesh, nvdim=3, value=m_fun, norm=Ms)
 
-        value = system.m((-1e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        value = system.m((1e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
+    value = system.m((-1e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        self.calculator.delete(system)
+    value = system.m((1e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
 
-    def test_field_vector_vector(self):
-        name = "cubicanisotropy_field_vector_vector"
+    self.calculator.delete(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        def K_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return 0
-            else:
-                return 1e5
+def test_cubic_anisotropy_field_vector_vector(cubic_anisotropy_case):
+    self = cubic_anisotropy_case
+    name = "cubicanisotropy_field_vector_vector"
 
-        K = df.Field(mesh, nvdim=1, value=K_fun)
-        u1 = (0, 0, 1)
-        u2 = (0, 1, 0)
-        Ms = 1e6
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        system = mm.System(name=name)
-        system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+    def K_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return 0
+        else:
+            return 1e5
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    K = df.Field(mesh, nvdim=1, value=K_fun)
+    u1 = (0, 0, 1)
+    u2 = (0, 1, 0)
+    Ms = 1e6
 
-        value = system.m((-2e-9, 1e-9, 1e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    value = system.m((-2e-9, 1e-9, 1e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
 
-    def test_field_field_field(self):
-        name = "cubicanisotropy_field_field_field"
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+    self.calculator.delete(system)
 
-        def K_fun(pos):
-            x, y, z = pos
-            if -2e-9 <= x <= 2e-9:
-                return 0
-            else:
-                return 1e5
 
-        def u1_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (0, 1, 0)
-            else:
-                return (0, 0, 1)
+def test_cubic_anisotropy_field_field_field(cubic_anisotropy_case):
+    self = cubic_anisotropy_case
+    name = "cubicanisotropy_field_field_field"
 
-        def u2_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (0, 0, 1)
-            else:
-                return (0, 1, 0)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        K = df.Field(mesh, nvdim=1, value=K_fun)
-        u1 = df.Field(mesh, nvdim=3, value=u1_fun)
-        u2 = df.Field(mesh, nvdim=3, value=u2_fun)
-        Ms = 1e6
+    def K_fun(pos):
+        x, y, z = pos
+        if -2e-9 <= x <= 2e-9:
+            return 0
+        else:
+            return 1e5
 
-        system = mm.System(name=name)
-        system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+    def u1_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (0, 1, 0)
+        else:
+            return (0, 0, 1)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    def u2_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (0, 0, 1)
+        else:
+            return (0, 1, 0)
 
-        value = system.m((0, 0, 0))
-        assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
+    K = df.Field(mesh, nvdim=1, value=K_fun)
+    u1 = df.Field(mesh, nvdim=3, value=u1_fun)
+    u2 = df.Field(mesh, nvdim=3, value=u2_fun)
+    Ms = 1e6
 
-        value = system.m((3e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-        value = system.m((-3e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    value = system.m((0, 0, 0))
+    assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
 
-    def test_dict_vector_vector(self):
-        name = "cubicanisotropy_dict_vector_vector"
+    value = system.m((3e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    value = system.m((-3e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        K = {"r1": 0, "r2": 1e5}
-        u1 = (0, 0, 1)
-        u2 = (0, 1, 0)
-        Ms = 1e6
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+def test_cubic_anisotropy_dict_vector_vector(cubic_anisotropy_case):
+    self = cubic_anisotropy_case
+    name = "cubicanisotropy_dict_vector_vector"
 
-        value = system.m((-2e-9, 1e-9, 1e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    K = {"r1": 0, "r2": 1e5}
+    u1 = (0, 0, 1)
+    u2 = (0, 1, 0)
+    Ms = 1e6
 
-        self.calculator.delete(system)
+    system = mm.System(name=name)
+    system.energy = mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m((-2e-9, 1e-9, 1e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
+
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/damping.py
+++ b/micromagnetictests/calculatortests/damping.py
@@ -23,46 +23,46 @@ def damping_case(calculator):
 
 
 def test_damping_scalar(damping_case):
-    self = damping_case
     name = "damping_scalar"
 
     H = (0, 0, 1e6)
     alpha = 0
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=damping_case.region, n=damping_case.n)
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.dynamics = mm.Damping(alpha=alpha)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = damping_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # Alpha is zero, nothing should change.
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    damping_case.calculator.delete(system)
 
 
 def test_damping_dict(damping_case):
-    self = damping_case
     name = "damping_dict"
 
     H = (0, 0, 1e6)
     alpha = {"r1": 0, "r2": 1}
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=damping_case.region, n=damping_case.n, subregions=damping_case.subregions
+    )
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.dynamics = mm.Damping(alpha=alpha)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = damping_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # alpha=0 region
@@ -73,14 +73,13 @@ def test_damping_dict(damping_case):
     value = system.m((1e-9, 4e-9, 3e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    damping_case.calculator.delete(system)
 
 
 def test_damping_field(damping_case):
-    self = damping_case
     name = "damping_field"
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=damping_case.region, n=damping_case.n)
 
     def value_fun(pos):
         x, y, z = pos
@@ -98,7 +97,7 @@ def test_damping_field(damping_case):
     system.dynamics = mm.Damping(alpha=alpha)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = damping_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # alpha=0 region
@@ -109,4 +108,4 @@ def test_damping_field(damping_case):
     value = system.m((1e-9, 4e-9, 3e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    damping_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/damping.py
+++ b/micromagnetictests/calculatortests/damping.py
@@ -1,104 +1,112 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestDamping:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def damping_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, -5e-9, -3e-9)
+    p2 = (5e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.n = (10, 10, 10)
+    case.subregions = {
+        "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-5e-9, -5e-9, -3e-9)
-        p2 = (5e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.n = (10, 10, 10)
-        self.subregions = {
-            "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def test_scalar(self):
-        name = "damping_scalar"
 
-        H = (0, 0, 1e6)
-        alpha = 0
-        Ms = 1e6
+def test_damping_scalar(damping_case):
+    self = damping_case
+    name = "damping_scalar"
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    H = (0, 0, 1e6)
+    alpha = 0
+    Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Damping(alpha=alpha)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Damping(alpha=alpha)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # Alpha is zero, nothing should change.
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        self.calculator.delete(system)
+    # Alpha is zero, nothing should change.
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
 
-    def test_dict(self):
-        name = "damping_dict"
+    self.calculator.delete(system)
 
-        H = (0, 0, 1e6)
-        alpha = {"r1": 0, "r2": 1}
-        Ms = 1e6
 
-        mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+def test_damping_dict(damping_case):
+    self = damping_case
+    name = "damping_dict"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Damping(alpha=alpha)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    H = (0, 0, 1e6)
+    alpha = {"r1": 0, "r2": 1}
+    Ms = 1e6
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
 
-        # alpha=0 region
-        value = system.m((1e-9, -4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Damping(alpha=alpha)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # alpha!=0 region
-        value = system.m((1e-9, 4e-9, 3e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        self.calculator.delete(system)
+    # alpha=0 region
+    value = system.m((1e-9, -4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
 
-    def test_field(self):
-        name = "damping_field"
+    # alpha!=0 region
+    value = system.m((1e-9, 4e-9, 3e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    self.calculator.delete(system)
 
-        def value_fun(pos):
-            x, y, z = pos
-            if y <= 0:
-                return 0
-            else:
-                return 1
 
-        H = (0, 0, 1e6)
-        alpha = df.Field(mesh, nvdim=1, value=value_fun)
-        Ms = 1e6
+def test_damping_field(damping_case):
+    self = damping_case
+    name = "damping_field"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Damping(alpha=alpha)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    def value_fun(pos):
+        x, y, z = pos
+        if y <= 0:
+            return 0
+        else:
+            return 1
 
-        # alpha=0 region
-        value = system.m((1e-9, -4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    H = (0, 0, 1e6)
+    alpha = df.Field(mesh, nvdim=1, value=value_fun)
+    Ms = 1e6
 
-        # alpha!=0 region
-        value = system.m((1e-9, 4e-9, 3e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Damping(alpha=alpha)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        self.calculator.delete(system)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
+
+    # alpha=0 region
+    value = system.m((1e-9, -4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+
+    # alpha!=0 region
+    value = system.m((1e-9, 4e-9, 3e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/demag.py
+++ b/micromagnetictests/calculatortests/demag.py
@@ -1,111 +1,123 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import pytest
 
 
-class TestDemag:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def demag_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, 0, 0)
+    p2 = (5e-9, 5e-9, 1e-9)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.mesh = df.Mesh(region=case.region, cell=case.cell)
 
-    def setup_method(self):
-        p1 = (-5e-9, 0, 0)
-        p2 = (5e-9, 5e-9, 1e-9)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.mesh = df.Mesh(region=self.region, cell=self.cell)
+    return case
 
-    def test_demag(self):
-        name = "demag"
 
-        Ms = 1e6
+def test_demag_demag(demag_case):
+    self = demag_case
+    name = "demag"
 
-        system = mm.System(name=name)
-        system.energy = mm.Demag()
+    Ms = 1e6
 
-        system.m = df.Field(self.mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    system = mm.System(name=name)
+    system.energy = mm.Demag()
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system.m = df.Field(self.mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        # Check if it runs. Tests to be added here.
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    # Check if it runs. Tests to be added here.
 
-    def test_demag_asymptotic_radius(self):
-        name = "demag_asymptotic_radius"
+    self.calculator.delete(system)
 
-        Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.Demag(asymptotic_radius=6)
+def test_demag_demag_asymptotic_radius(demag_case):
+    self = demag_case
+    name = "demag_asymptotic_radius"
 
-        system.m = df.Field(self.mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+    Ms = 1e6
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system = mm.System(name=name)
+    system.energy = mm.Demag(asymptotic_radius=6)
 
-        # Check if it runs. Tests to be added here.
+    system.m = df.Field(self.mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
 
-        self.calculator.delete(system)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-    def test_demag_1_pbc(self):
-        name = "demag_pbc"
+    # Check if it runs. Tests to be added here.
 
-        Ms = 1e6
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.Demag()
 
-        md = self.calculator.MinDriver()
+def test_demag_demag_1_pbc(demag_case):
+    self = demag_case
+    name = "demag_pbc"
 
-        # 1D pbc
-        mesh = df.Mesh(region=self.region, cell=self.cell, bc="x")
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+    Ms = 1e6
 
-        md.drive(system)
-        self.calculator.delete(system)
+    system = mm.System(name=name)
+    system.energy = mm.Demag()
 
-    def test_demag_2_pbc(self):
-        name = "demag_pbc"
+    md = self.calculator.MinDriver()
 
-        Ms = 1e6
+    # 1D pbc
+    mesh = df.Mesh(region=self.region, cell=self.cell, bc="x")
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
 
-        system = mm.System(name=name)
-        system.energy = mm.Demag()
+    md.drive(system)
+    self.calculator.delete(system)
 
-        md = self.calculator.MinDriver()
 
-        # 2D pbc
-        mesh = df.Mesh(region=self.region, cell=self.cell, bc="xy")
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+def test_demag_demag_2_pbc(demag_case):
+    self = demag_case
+    name = "demag_pbc"
 
-        if not hasattr(self.calculator, "RelaxDriver"):
-            with pytest.raises(ValueError):
-                md.drive(system)
-        else:
+    Ms = 1e6
+
+    system = mm.System(name=name)
+    system.energy = mm.Demag()
+
+    md = self.calculator.MinDriver()
+
+    # 2D pbc
+    mesh = df.Mesh(region=self.region, cell=self.cell, bc="xy")
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+
+    if not hasattr(self.calculator, "RelaxDriver"):
+        with pytest.raises(ValueError):
             md.drive(system)
+    else:
+        md.drive(system)
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)
 
-    def test_demag_3_pbc(self):
-        name = "demag_pbc"
 
-        Ms = 1e6
+def test_demag_demag_3_pbc(demag_case):
+    self = demag_case
+    name = "demag_pbc"
 
-        system = mm.System(name=name)
-        system.energy = mm.Demag()
+    Ms = 1e6
 
-        md = self.calculator.MinDriver()
+    system = mm.System(name=name)
+    system.energy = mm.Demag()
 
-        # 3D pbc
-        mesh = df.Mesh(region=self.region, cell=self.cell, bc="xyz")
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+    md = self.calculator.MinDriver()
 
-        if not hasattr(self.calculator, "RelaxDriver"):
-            with pytest.raises(ValueError):
-                md.drive(system)
-        else:
+    # 3D pbc
+    mesh = df.Mesh(region=self.region, cell=self.cell, bc="xyz")
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+
+    if not hasattr(self.calculator, "RelaxDriver"):
+        with pytest.raises(ValueError):
             md.drive(system)
+    else:
+        md.drive(system)
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/demag.py
+++ b/micromagnetictests/calculatortests/demag.py
@@ -19,7 +19,6 @@ def demag_case(calculator):
 
 
 def test_demag_demag(demag_case):
-    self = demag_case
     name = "demag"
 
     Ms = 1e6
@@ -27,18 +26,17 @@ def test_demag_demag(demag_case):
     system = mm.System(name=name)
     system.energy = mm.Demag()
 
-    system.m = df.Field(self.mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    system.m = df.Field(demag_case.mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = demag_case.calculator.MinDriver()
     md.drive(system)
 
     # Check if it runs. Tests to be added here.
 
-    self.calculator.delete(system)
+    demag_case.calculator.delete(system)
 
 
 def test_demag_demag_asymptotic_radius(demag_case):
-    self = demag_case
     name = "demag_asymptotic_radius"
 
     Ms = 1e6
@@ -46,18 +44,17 @@ def test_demag_demag_asymptotic_radius(demag_case):
     system = mm.System(name=name)
     system.energy = mm.Demag(asymptotic_radius=6)
 
-    system.m = df.Field(self.mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
+    system.m = df.Field(demag_case.mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = demag_case.calculator.MinDriver()
     md.drive(system)
 
     # Check if it runs. Tests to be added here.
 
-    self.calculator.delete(system)
+    demag_case.calculator.delete(system)
 
 
 def test_demag_demag_1_pbc(demag_case):
-    self = demag_case
     name = "demag_pbc"
 
     Ms = 1e6
@@ -65,18 +62,17 @@ def test_demag_demag_1_pbc(demag_case):
     system = mm.System(name=name)
     system.energy = mm.Demag()
 
-    md = self.calculator.MinDriver()
+    md = demag_case.calculator.MinDriver()
 
     # 1D pbc
-    mesh = df.Mesh(region=self.region, cell=self.cell, bc="x")
+    mesh = df.Mesh(region=demag_case.region, cell=demag_case.cell, bc="x")
     system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
 
     md.drive(system)
-    self.calculator.delete(system)
+    demag_case.calculator.delete(system)
 
 
 def test_demag_demag_2_pbc(demag_case):
-    self = demag_case
     name = "demag_pbc"
 
     Ms = 1e6
@@ -84,23 +80,22 @@ def test_demag_demag_2_pbc(demag_case):
     system = mm.System(name=name)
     system.energy = mm.Demag()
 
-    md = self.calculator.MinDriver()
+    md = demag_case.calculator.MinDriver()
 
     # 2D pbc
-    mesh = df.Mesh(region=self.region, cell=self.cell, bc="xy")
+    mesh = df.Mesh(region=demag_case.region, cell=demag_case.cell, bc="xy")
     system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
 
-    if not hasattr(self.calculator, "RelaxDriver"):
+    if not hasattr(demag_case.calculator, "RelaxDriver"):
         with pytest.raises(ValueError):
             md.drive(system)
     else:
         md.drive(system)
 
-    self.calculator.delete(system)
+    demag_case.calculator.delete(system)
 
 
 def test_demag_demag_3_pbc(demag_case):
-    self = demag_case
     name = "demag_pbc"
 
     Ms = 1e6
@@ -108,16 +103,16 @@ def test_demag_demag_3_pbc(demag_case):
     system = mm.System(name=name)
     system.energy = mm.Demag()
 
-    md = self.calculator.MinDriver()
+    md = demag_case.calculator.MinDriver()
 
     # 3D pbc
-    mesh = df.Mesh(region=self.region, cell=self.cell, bc="xyz")
+    mesh = df.Mesh(region=demag_case.region, cell=demag_case.cell, bc="xyz")
     system.m = df.Field(mesh, nvdim=3, value=(0, 0, 1), norm=Ms)
 
-    if not hasattr(self.calculator, "RelaxDriver"):
+    if not hasattr(demag_case.calculator, "RelaxDriver"):
         with pytest.raises(ValueError):
             md.drive(system)
     else:
         md.drive(system)
 
-    self.calculator.delete(system)
+    demag_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/dmi.py
+++ b/micromagnetictests/calculatortests/dmi.py
@@ -28,7 +28,6 @@ def random_m(pos):
 
 
 def test_dmi_scalar(dmi_case):
-    self = dmi_case
     name = "dmi_scalar"
 
     D = 1e-3
@@ -37,17 +36,17 @@ def test_dmi_scalar(dmi_case):
     system = mm.System(name=name)
     system.energy = mm.DMI(D=D, crystalclass="Cnv_z")
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
-    system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
+    mesh = df.Mesh(region=dmi_case.region, cell=dmi_case.cell)
+    system.m = df.Field(mesh, nvdim=3, value=dmi_case.random_m, norm=Ms)
 
-    if hasattr(self.calculator, "RelaxDriver"):
+    if hasattr(dmi_case.calculator, "RelaxDriver"):
         system.dynamics = mm.Damping(alpha=0.5)
-        md = self.calculator.RelaxDriver()
+        md = dmi_case.calculator.RelaxDriver()
         with pytest.raises(RuntimeError):
             md.drive(system)
         system.energy += mm.Exchange(A=1e-21)
     else:
-        md = self.calculator.MinDriver()
+        md = dmi_case.calculator.MinDriver()
 
     md.drive(system)
 
@@ -55,11 +54,10 @@ def test_dmi_scalar(dmi_case):
     # 0.
     assert np.linalg.norm(system.m.mean()) < 1
 
-    self.calculator.delete(system)
+    dmi_case.calculator.delete(system)
 
 
 def test_dmi_dict(dmi_case):
-    self = dmi_case
     name = "dmi_dict"
 
     D = {"r1": 0, "r2": 1e-3, "default": 2e-3}
@@ -68,17 +66,19 @@ def test_dmi_dict(dmi_case):
     system = mm.System(name=name)
     system.energy = mm.DMI(D=D, crystalclass="Cnv_z")
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-    system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
+    mesh = df.Mesh(
+        region=dmi_case.region, cell=dmi_case.cell, subregions=dmi_case.subregions
+    )
+    system.m = df.Field(mesh, nvdim=3, value=dmi_case.random_m, norm=Ms)
 
-    if hasattr(self.calculator, "RelaxDriver"):
+    if hasattr(dmi_case.calculator, "RelaxDriver"):
         system.dynamics = mm.Damping(alpha=0.5)
-        md = self.calculator.RelaxDriver()
+        md = dmi_case.calculator.RelaxDriver()
         with pytest.raises(RuntimeError):
             md.drive(system)
         system.energy += mm.Exchange(A=1e-21)
     else:
-        md = self.calculator.MinDriver()
+        md = dmi_case.calculator.MinDriver()
     md.drive(system)
 
     assert np.linalg.norm(system.m["r1"].mean()) > 1
@@ -86,13 +86,12 @@ def test_dmi_dict(dmi_case):
     # the average should be 0.
     assert np.linalg.norm(system.m["r2"].mean()) < 1
 
-    self.calculator.delete(system)
+    dmi_case.calculator.delete(system)
 
 
 @pytest.mark.filterwarnings("ignore:Use of `Cnv` is deprecated:FutureWarning")
 @pytest.mark.filterwarnings("ignore:Use of `D2d` is deprecated:FutureWarning")
 def test_dmi_crystalclass(dmi_case):
-    self = dmi_case
     name = "dmi_crystalclass"
 
     D = 1e-3
@@ -114,26 +113,27 @@ def test_dmi_crystalclass(dmi_case):
         system.energy = mm.DMI(D=D, crystalclass=crystalclass)
 
         if crystalclass.endswith(("x", "y")):
-            mesh = df.Mesh(p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=self.cell)
+            mesh = df.Mesh(
+                p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=dmi_case.cell
+            )
         else:
-            mesh = df.Mesh(region=self.region, cell=self.cell)
+            mesh = df.Mesh(region=dmi_case.region, cell=dmi_case.cell)
 
-        system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
+        system.m = df.Field(mesh, nvdim=3, value=dmi_case.random_m, norm=Ms)
 
-        md = self.calculator.MinDriver()
+        md = dmi_case.calculator.MinDriver()
         md.drive(system)
 
         # There are 4N cells in the mesh. Because of that the
         # average should be 0.
         assert np.linalg.norm(system.m.mean()) < 1
 
-    self.calculator.delete(system)
+    dmi_case.calculator.delete(system)
 
 
 @pytest.mark.filterwarnings("ignore:Use of `Cnv` is deprecated:FutureWarning")
 @pytest.mark.filterwarnings("ignore:Use of `D2d` is deprecated:FutureWarning")
 def test_dmi_crystalclass_init(dmi_case):
-    self = dmi_case
     name = "dmi_crystalclass"
 
     D = 1e-3
@@ -157,14 +157,16 @@ def test_dmi_crystalclass_init(dmi_case):
         system.energy = mm.DMI(D=D, crystalclass=crystalclass)
 
         if crystalclass.endswith(("x", "y")):
-            mesh = df.Mesh(p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=self.cell)
+            mesh = df.Mesh(
+                p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=dmi_case.cell
+            )
         else:
-            mesh = df.Mesh(region=self.region, cell=self.cell)
+            mesh = df.Mesh(region=dmi_case.region, cell=dmi_case.cell)
 
-        system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
+        system.m = df.Field(mesh, nvdim=3, value=dmi_case.random_m, norm=Ms)
 
-        md = self.calculator.MinDriver()
-        if hasattr(self.calculator, "RelaxDriver"):
+        md = dmi_case.calculator.MinDriver()
+        if hasattr(dmi_case.calculator, "RelaxDriver"):
             system.energy += mm.Exchange(A=1e-21)
             if crystalclass not in mumax3_cc:
                 with pytest.raises(ValueError):
@@ -174,4 +176,4 @@ def test_dmi_crystalclass_init(dmi_case):
         else:
             md.drive(system)
 
-    self.calculator.delete(system)
+    dmi_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/dmi.py
+++ b/micromagnetictests/calculatortests/dmi.py
@@ -1,4 +1,5 @@
 import random
+from types import SimpleNamespace
 
 import discretisedfield as df
 import micromagneticmodel as mm
@@ -6,166 +7,171 @@ import numpy as np
 import pytest
 
 
-class TestDMI:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def dmi_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-100e-9, 0, 0)
+    p2 = (100e-9, 1e-9, 1e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.subregions = {
+        "r1": df.Region(p1=(-100e-9, 0, 0), p2=(0, 1e-9, 1e-9)),
+        "r2": df.Region(p1=(0, 0, 0), p2=(100e-9, 1e-9, 1e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-100e-9, 0, 0)
-        p2 = (100e-9, 1e-9, 1e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.subregions = {
-            "r1": df.Region(p1=(-100e-9, 0, 0), p2=(0, 1e-9, 1e-9)),
-            "r2": df.Region(p1=(0, 0, 0), p2=(100e-9, 1e-9, 1e-9)),
-        }
+    return case
 
-    def random_m(self, pos):
-        return [2 * random.random() - 1 for i in range(3)]
 
-    def test_scalar(self):
-        name = "dmi_scalar"
+def random_m(pos):
+    return [2 * random.random() - 1 for i in range(3)]
 
-        D = 1e-3
-        Ms = 1e6
 
+def test_dmi_scalar(dmi_case):
+    self = dmi_case
+    name = "dmi_scalar"
+
+    D = 1e-3
+    Ms = 1e6
+
+    system = mm.System(name=name)
+    system.energy = mm.DMI(D=D, crystalclass="Cnv_z")
+
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
+
+    if hasattr(self.calculator, "RelaxDriver"):
+        system.dynamics = mm.Damping(alpha=0.5)
+        md = self.calculator.RelaxDriver()
+        with pytest.raises(RuntimeError):
+            md.drive(system)
+        system.energy += mm.Exchange(A=1e-21)
+    else:
+        md = self.calculator.MinDriver()
+
+    md.drive(system)
+
+    # There are 4N cells in the mesh. Because of that the average should be
+    # 0.
+    assert np.linalg.norm(system.m.mean()) < 1
+
+    self.calculator.delete(system)
+
+
+def test_dmi_dict(dmi_case):
+    self = dmi_case
+    name = "dmi_dict"
+
+    D = {"r1": 0, "r2": 1e-3, "default": 2e-3}
+    Ms = 1e6
+
+    system = mm.System(name=name)
+    system.energy = mm.DMI(D=D, crystalclass="Cnv_z")
+
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
+
+    if hasattr(self.calculator, "RelaxDriver"):
+        system.dynamics = mm.Damping(alpha=0.5)
+        md = self.calculator.RelaxDriver()
+        with pytest.raises(RuntimeError):
+            md.drive(system)
+        system.energy += mm.Exchange(A=1e-21)
+    else:
+        md = self.calculator.MinDriver()
+    md.drive(system)
+
+    assert np.linalg.norm(system.m["r1"].mean()) > 1
+    # There are 4N cells in the region with D!=0. Because of that
+    # the average should be 0.
+    assert np.linalg.norm(system.m["r2"].mean()) < 1
+
+    self.calculator.delete(system)
+
+
+@pytest.mark.filterwarnings("ignore:Use of `Cnv` is deprecated:FutureWarning")
+@pytest.mark.filterwarnings("ignore:Use of `D2d` is deprecated:FutureWarning")
+def test_dmi_crystalclass(dmi_case):
+    self = dmi_case
+    name = "dmi_crystalclass"
+
+    D = 1e-3
+    Ms = 1e6
+
+    for crystalclass in [
+        "Cnv_x",
+        "Cnv_y",
+        "Cnv_z",
+        "T",
+        "O",
+        "D2d_x",
+        "D2d_y",
+        "D2d_z",
+        "Cnv",
+        "D2d",  # legacy crystalclass names
+    ]:
         system = mm.System(name=name)
-        system.energy = mm.DMI(D=D, crystalclass="Cnv_z")
+        system.energy = mm.DMI(D=D, crystalclass=crystalclass)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+        if crystalclass.endswith(("x", "y")):
+            mesh = df.Mesh(p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=self.cell)
+        else:
+            mesh = df.Mesh(region=self.region, cell=self.cell)
+
         system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
 
-        if hasattr(self.calculator, "RelaxDriver"):
-            system.dynamics = mm.Damping(alpha=0.5)
-            md = self.calculator.RelaxDriver()
-            with pytest.raises(RuntimeError):
-                md.drive(system)
-            system.energy += mm.Exchange(A=1e-21)
-        else:
-            md = self.calculator.MinDriver()
-
+        md = self.calculator.MinDriver()
         md.drive(system)
 
-        # There are 4N cells in the mesh. Because of that the average should be
-        # 0.
+        # There are 4N cells in the mesh. Because of that the
+        # average should be 0.
         assert np.linalg.norm(system.m.mean()) < 1
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)
 
-    def test_dict(self):
-        name = "dmi_dict"
 
-        D = {"r1": 0, "r2": 1e-3, "default": 2e-3}
-        Ms = 1e6
+@pytest.mark.filterwarnings("ignore:Use of `Cnv` is deprecated:FutureWarning")
+@pytest.mark.filterwarnings("ignore:Use of `D2d` is deprecated:FutureWarning")
+def test_dmi_crystalclass_init(dmi_case):
+    self = dmi_case
+    name = "dmi_crystalclass"
 
+    D = 1e-3
+    Ms = 1e6
+
+    mumax3_cc = ["Cnv_z", "T", "O", "Cnv"]
+
+    for crystalclass in [
+        "Cnv_x",
+        "Cnv_y",
+        "Cnv_z",
+        "T",
+        "O",
+        "D2d_x",
+        "D2d_y",
+        "D2d_z",
+        "Cnv",
+        "D2d",  # legacy crystalclass names
+    ]:
         system = mm.System(name=name)
-        system.energy = mm.DMI(D=D, crystalclass="Cnv_z")
+        system.energy = mm.DMI(D=D, crystalclass=crystalclass)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+        if crystalclass.endswith(("x", "y")):
+            mesh = df.Mesh(p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=self.cell)
+        else:
+            mesh = df.Mesh(region=self.region, cell=self.cell)
+
         system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
 
+        md = self.calculator.MinDriver()
         if hasattr(self.calculator, "RelaxDriver"):
-            system.dynamics = mm.Damping(alpha=0.5)
-            md = self.calculator.RelaxDriver()
-            with pytest.raises(RuntimeError):
-                md.drive(system)
             system.energy += mm.Exchange(A=1e-21)
-        else:
-            md = self.calculator.MinDriver()
-        md.drive(system)
-
-        assert np.linalg.norm(system.m["r1"].mean()) > 1
-        # There are 4N cells in the region with D!=0. Because of that
-        # the average should be 0.
-        assert np.linalg.norm(system.m["r2"].mean()) < 1
-
-        self.calculator.delete(system)
-
-    @pytest.mark.filterwarnings("ignore:Use of `Cnv` is deprecated:FutureWarning")
-    @pytest.mark.filterwarnings("ignore:Use of `D2d` is deprecated:FutureWarning")
-    def test_crystalclass(self):
-        name = "dmi_crystalclass"
-
-        D = 1e-3
-        Ms = 1e6
-
-        for crystalclass in [
-            "Cnv_x",
-            "Cnv_y",
-            "Cnv_z",
-            "T",
-            "O",
-            "D2d_x",
-            "D2d_y",
-            "D2d_z",
-            "Cnv",
-            "D2d",  # legacy crystalclass names
-        ]:
-            system = mm.System(name=name)
-            system.energy = mm.DMI(D=D, crystalclass=crystalclass)
-
-            if crystalclass.endswith(("x", "y")):
-                mesh = df.Mesh(
-                    p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=self.cell
-                )
-            else:
-                mesh = df.Mesh(region=self.region, cell=self.cell)
-
-            system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
-
-            md = self.calculator.MinDriver()
-            md.drive(system)
-
-            # There are 4N cells in the mesh. Because of that the
-            # average should be 0.
-            assert np.linalg.norm(system.m.mean()) < 1
-
-        self.calculator.delete(system)
-
-    @pytest.mark.filterwarnings("ignore:Use of `Cnv` is deprecated:FutureWarning")
-    @pytest.mark.filterwarnings("ignore:Use of `D2d` is deprecated:FutureWarning")
-    def test_crystalclass_init(self):
-        name = "dmi_crystalclass"
-
-        D = 1e-3
-        Ms = 1e6
-
-        mumax3_cc = ["Cnv_z", "T", "O", "Cnv"]
-
-        for crystalclass in [
-            "Cnv_x",
-            "Cnv_y",
-            "Cnv_z",
-            "T",
-            "O",
-            "D2d_x",
-            "D2d_y",
-            "D2d_z",
-            "Cnv",
-            "D2d",  # legacy crystalclass names
-        ]:
-            system = mm.System(name=name)
-            system.energy = mm.DMI(D=D, crystalclass=crystalclass)
-
-            if crystalclass.endswith(("x", "y")):
-                mesh = df.Mesh(
-                    p1=(0, 0, -100e-9), p2=(1e-9, 1e-9, 100e-9), cell=self.cell
-                )
-            else:
-                mesh = df.Mesh(region=self.region, cell=self.cell)
-
-            system.m = df.Field(mesh, nvdim=3, value=self.random_m, norm=Ms)
-
-            md = self.calculator.MinDriver()
-            if hasattr(self.calculator, "RelaxDriver"):
-                system.energy += mm.Exchange(A=1e-21)
-                if crystalclass not in mumax3_cc:
-                    with pytest.raises(ValueError):
-                        md.drive(system)
-                else:
+            if crystalclass not in mumax3_cc:
+                with pytest.raises(ValueError):
                     md.drive(system)
             else:
                 md.drive(system)
+        else:
+            md.drive(system)
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/dynamics.py
+++ b/micromagnetictests/calculatortests/dynamics.py
@@ -23,7 +23,6 @@ def dynamics_case(calculator):
 
 
 def test_dynamics_scalar_scalar(dynamics_case):
-    self = dynamics_case
     name = "dynamics_scalar_scalar"
 
     H = (0, 0, 1e6)
@@ -31,25 +30,24 @@ def test_dynamics_scalar_scalar(dynamics_case):
     gamma0 = 2.211e5
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=dynamics_case.region, n=dynamics_case.n)
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = dynamics_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # Alpha is zero, nothing should change.
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
 
-    self.calculator.delete(system)
+    dynamics_case.calculator.delete(system)
 
 
 def test_dynamics_scalar_dict(dynamics_case):
-    self = dynamics_case
     name = "dynamics_scalar_dict"
 
     H = (0, 0, 1e6)
@@ -57,14 +55,18 @@ def test_dynamics_scalar_dict(dynamics_case):
     alpha = {"r1": 0, "r2": 1}
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=dynamics_case.region,
+        n=dynamics_case.n,
+        subregions=dynamics_case.subregions,
+    )
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = dynamics_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # alpha=0 region
@@ -75,14 +77,13 @@ def test_dynamics_scalar_dict(dynamics_case):
     value = system.m((1e-9, 4e-9, 3e-9))
     assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
 
-    self.calculator.delete(system)
+    dynamics_case.calculator.delete(system)
 
 
 def test_dynamics_field_field(dynamics_case):
-    self = dynamics_case
     name = "dynamics_field_field"
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=dynamics_case.region, n=dynamics_case.n)
 
     def alpha_fun(pos):
         x, y, z = pos
@@ -108,7 +109,7 @@ def test_dynamics_field_field(dynamics_case):
     system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = dynamics_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # alpha=0 and gamma=0 region
@@ -119,4 +120,4 @@ def test_dynamics_field_field(dynamics_case):
     value = system.m((1e-9, 4e-9, 3e-9))
     assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
 
-    self.calculator.delete(system)
+    dynamics_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/dynamics.py
+++ b/micromagnetictests/calculatortests/dynamics.py
@@ -1,114 +1,122 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestDynamics:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def dynamics_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, -5e-9, -3e-9)
+    p2 = (5e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.n = (10, 10, 10)
+    case.subregions = {
+        "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-5e-9, -5e-9, -3e-9)
-        p2 = (5e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.n = (10, 10, 10)
-        self.subregions = {
-            "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def test_scalar_scalar(self):
-        name = "dynamics_scalar_scalar"
 
-        H = (0, 0, 1e6)
-        alpha = 1
-        gamma0 = 2.211e5
-        Ms = 1e6
+def test_dynamics_scalar_scalar(dynamics_case):
+    self = dynamics_case
+    name = "dynamics_scalar_scalar"
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    H = (0, 0, 1e6)
+    alpha = 1
+    gamma0 = 2.211e5
+    Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # Alpha is zero, nothing should change.
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        self.calculator.delete(system)
+    # Alpha is zero, nothing should change.
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
 
-    def test_scalar_dict(self):
-        name = "dynamics_scalar_dict"
+    self.calculator.delete(system)
 
-        H = (0, 0, 1e6)
-        gamma0 = 2.211e5
-        alpha = {"r1": 0, "r2": 1}
-        Ms = 1e6
 
-        mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+def test_dynamics_scalar_dict(dynamics_case):
+    self = dynamics_case
+    name = "dynamics_scalar_dict"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    H = (0, 0, 1e6)
+    gamma0 = 2.211e5
+    alpha = {"r1": 0, "r2": 1}
+    Ms = 1e6
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
 
-        # alpha=0 region
-        value = system.m((1e-9, -4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0, Ms))) > 1
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # alpha!=0 region
-        value = system.m((1e-9, 4e-9, 3e-9))
-        assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        self.calculator.delete(system)
+    # alpha=0 region
+    value = system.m((1e-9, -4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0, Ms))) > 1
 
-    def test_field_field(self):
-        name = "dynamics_field_field"
+    # alpha!=0 region
+    value = system.m((1e-9, 4e-9, 3e-9))
+    assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    self.calculator.delete(system)
 
-        def alpha_fun(pos):
-            x, y, z = pos
-            if y <= 0:
-                return 0
-            else:
-                return 1
 
-        def gamma0_fun(pos):
-            x, y, z = pos
-            if y <= 0:
-                return 0
-            else:
-                return 2.211e5
+def test_dynamics_field_field(dynamics_case):
+    self = dynamics_case
+    name = "dynamics_field_field"
 
-        H = (0, 0, 1e6)
-        alpha = df.Field(mesh, nvdim=1, value=alpha_fun)
-        gamma0 = df.Field(mesh, nvdim=1, value=gamma0_fun)
-        Ms = 1e6
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    def alpha_fun(pos):
+        x, y, z = pos
+        if y <= 0:
+            return 0
+        else:
+            return 1
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    def gamma0_fun(pos):
+        x, y, z = pos
+        if y <= 0:
+            return 0
+        else:
+            return 2.211e5
 
-        # alpha=0 and gamma=0 region
-        value = system.m((1e-9, -4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    H = (0, 0, 1e6)
+    alpha = df.Field(mesh, nvdim=1, value=alpha_fun)
+    gamma0 = df.Field(mesh, nvdim=1, value=gamma0_fun)
+    Ms = 1e6
 
-        # alpha!=0 and gamma!=0 region
-        value = system.m((1e-9, 4e-9, 3e-9))
-        assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Precession(gamma0=gamma0) + mm.Damping(alpha=alpha)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        self.calculator.delete(system)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
+
+    # alpha=0 and gamma=0 region
+    value = system.m((1e-9, -4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+
+    # alpha!=0 and gamma!=0 region
+    value = system.m((1e-9, 4e-9, 3e-9))
+    assert np.linalg.norm(np.subtract(np.divide(value, Ms), (0, 0, 1))) < 1e-5
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/energy.py
+++ b/micromagnetictests/calculatortests/energy.py
@@ -23,34 +23,32 @@ def energy_case(calculator):
 
 
 def test_energy_exchange_zeeman(energy_case):
-    self = energy_case
     name = "energy_exchange_zeeman"
 
     A = 1e-12
     H = (1e6, 0, 0)
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=energy_case.region, cell=energy_case.cell)
 
     system = mm.System(name=name)
     system.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
     system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-    if hasattr(self.calculator, "RelaxDriver"):
+    if hasattr(energy_case.calculator, "RelaxDriver"):
         system.dynamics = mm.Damping(alpha=0.5)
-        md = self.calculator.RelaxDriver()
+        md = energy_case.calculator.RelaxDriver()
     else:
-        md = self.calculator.MinDriver()
+        md = energy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    energy_case.calculator.delete(system)
 
 
 def test_energy_exchange_uniaxialanisotropy(energy_case):
-    self = energy_case
     name = "exchange_uniaxialanisotropy"
 
     A = {"r1": 1e-12, "r2": 0}
@@ -58,27 +56,30 @@ def test_energy_exchange_uniaxialanisotropy(energy_case):
     u = (1, 0, 0)
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=energy_case.region,
+        cell=energy_case.cell,
+        subregions=energy_case.subregions,
+    )
 
     system = mm.System(name=name)
     system.energy = mm.Exchange(A=A) + mm.UniaxialAnisotropy(K=K, u=u)
     system.m = df.Field(mesh, nvdim=3, value=(0.5, 1, 0), norm=Ms)
 
-    if hasattr(self.calculator, "RelaxDriver"):
+    if hasattr(energy_case.calculator, "RelaxDriver"):
         system.dynamics = mm.Damping(alpha=0.5)
-        md = self.calculator.RelaxDriver()
+        md = energy_case.calculator.RelaxDriver()
     else:
-        md = self.calculator.MinDriver()
+        md = energy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    energy_case.calculator.delete(system)
 
 
 def test_energy_exchange_cubicanisotropy(energy_case):
-    self = energy_case
     name = "exchange_cubicanisotropy"
 
     A = {"r1": 1e-12, "r2": 0}
@@ -87,26 +88,33 @@ def test_energy_exchange_cubicanisotropy(energy_case):
     u2 = (0, 1, 0)
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=energy_case.region,
+        cell=energy_case.cell,
+        subregions=energy_case.subregions,
+    )
 
     system = mm.System(name=name)
     system.energy = mm.Exchange(A=A) + mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
     system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = energy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    energy_case.calculator.delete(system)
 
 
 def test_energy_exchange_dmi_zeeman(energy_case):
-    self = energy_case
     name = "exchange_dmi_zeeman"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=energy_case.region,
+        cell=energy_case.cell,
+        subregions=energy_case.subregions,
+    )
 
     # Very weak DMI and strong Zeeman to make the final
     # magnetisation uniform.
@@ -121,20 +129,23 @@ def test_energy_exchange_dmi_zeeman(energy_case):
     )
     system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = energy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1
 
-    self.calculator.delete(system)
+    energy_case.calculator.delete(system)
 
 
 def test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag(energy_case):
-    self = energy_case
     name = "exchange_dmi_zeeman_uniaxialanisotropy"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=energy_case.region,
+        cell=energy_case.cell,
+        subregions=energy_case.subregions,
+    )
 
     # Very weak DMI and strong Zeeman to make the final
     # magnetisation uniform.
@@ -155,17 +166,16 @@ def test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag(energy_case):
     )
     system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = energy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1
 
-    self.calculator.delete(system)
+    energy_case.calculator.delete(system)
 
 
 def test_energy_zeeman_zeeman(energy_case):
-    self = energy_case
     name = "multi_zeeman_field"
 
     def value_fun(pos):
@@ -175,7 +185,7 @@ def test_energy_zeeman_zeeman(energy_case):
         else:
             return (0, 0, 1e6)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=energy_case.region, cell=energy_case.cell)
 
     H1 = df.Field(mesh, nvdim=3, value=value_fun)
     H2 = df.Field(mesh, nvdim=3, value=(0, 1e6, 0))
@@ -185,9 +195,9 @@ def test_energy_zeeman_zeeman(energy_case):
     system.energy = mm.Zeeman(H=H1, name="zeeman1") + mm.Zeeman(H=H2, name="zeeman2")
     system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = energy_case.calculator.MinDriver()
     md.drive(system)
 
     # test if it runs
 
-    self.calculator.delete(system)
+    energy_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/energy.py
+++ b/micromagnetictests/calculatortests/energy.py
@@ -1,181 +1,193 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestEnergy:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def energy_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (0, 0, 0)
+    p2 = (10e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.subregions = {
+        "r1": df.Region(p1=(0, 0, 0), p2=(5e-9, 5e-9, 3e-9)),
+        "r2": df.Region(p1=(5e-9, 0, 0), p2=(10e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (0, 0, 0)
-        p2 = (10e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.subregions = {
-            "r1": df.Region(p1=(0, 0, 0), p2=(5e-9, 5e-9, 3e-9)),
-            "r2": df.Region(p1=(5e-9, 0, 0), p2=(10e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def test_exchange_zeeman(self):
-        name = "energy_exchange_zeeman"
 
-        A = 1e-12
-        H = (1e6, 0, 0)
-        Ms = 1e6
+def test_energy_exchange_zeeman(energy_case):
+    self = energy_case
+    name = "energy_exchange_zeeman"
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+    A = 1e-12
+    H = (1e6, 0, 0)
+    Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        if hasattr(self.calculator, "RelaxDriver"):
-            system.dynamics = mm.Damping(alpha=0.5)
-            md = self.calculator.RelaxDriver()
+    system = mm.System(name=name)
+    system.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
+
+    if hasattr(self.calculator, "RelaxDriver"):
+        system.dynamics = mm.Damping(alpha=0.5)
+        md = self.calculator.RelaxDriver()
+    else:
+        md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+
+    self.calculator.delete(system)
+
+
+def test_energy_exchange_uniaxialanisotropy(energy_case):
+    self = energy_case
+    name = "exchange_uniaxialanisotropy"
+
+    A = {"r1": 1e-12, "r2": 0}
+    K = 1e5
+    u = (1, 0, 0)
+    Ms = 1e6
+
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+
+    system = mm.System(name=name)
+    system.energy = mm.Exchange(A=A) + mm.UniaxialAnisotropy(K=K, u=u)
+    system.m = df.Field(mesh, nvdim=3, value=(0.5, 1, 0), norm=Ms)
+
+    if hasattr(self.calculator, "RelaxDriver"):
+        system.dynamics = mm.Damping(alpha=0.5)
+        md = self.calculator.RelaxDriver()
+    else:
+        md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+
+    self.calculator.delete(system)
+
+
+def test_energy_exchange_cubicanisotropy(energy_case):
+    self = energy_case
+    name = "exchange_cubicanisotropy"
+
+    A = {"r1": 1e-12, "r2": 0}
+    K = 1e5
+    u1 = (1, 0, 0)
+    u2 = (0, 1, 0)
+    Ms = 1e6
+
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+
+    system = mm.System(name=name)
+    system.energy = mm.Exchange(A=A) + mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+
+    self.calculator.delete(system)
+
+
+def test_energy_exchange_dmi_zeeman(energy_case):
+    self = energy_case
+    name = "exchange_dmi_zeeman"
+
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+
+    # Very weak DMI and strong Zeeman to make the final
+    # magnetisation uniform.
+    A = {"r1": 1e-12, "r2": 3e-12, "r1:r2": 2e-12}
+    D = {"r1": 1e-9, "r2": 0, "r1:r2": 5e-9}
+    H = df.Field(mesh, nvdim=3, value=(1e10, 0, 0))
+    Ms = 1e6
+
+    system = mm.System(name=name)
+    system.energy = (
+        mm.Exchange(A=A) + mm.DMI(D=D, crystalclass="Cnv_z") + mm.Zeeman(H=H)
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1
+
+    self.calculator.delete(system)
+
+
+def test_energy_exchange_dmi_zeeman_uniaxialanisotropy_demag(energy_case):
+    self = energy_case
+    name = "exchange_dmi_zeeman_uniaxialanisotropy"
+
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+
+    # Very weak DMI and strong Zeeman to make the final
+    # magnetisation uniform.
+    A = {"r1": 1e-12, "r2": 3e-12, "r1:r2": 2e-12}
+    D = {"r1": 1e-9, "r2": 0, "r1:r2": 5e-9}  # Very weak DMI
+    H = df.Field(mesh, nvdim=3, value=(1e12, 0, 0))
+    K = 1e6
+    u = (1, 0, 0)
+    Ms = 1e5
+
+    system = mm.System(name=name)
+    system.energy = (
+        mm.Exchange(A=A)
+        + mm.DMI(D=D, crystalclass="Cnv_z")
+        + mm.UniaxialAnisotropy(K=K, u=u)
+        + mm.Zeeman(H=H)
+        + mm.Demag()
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1
+
+    self.calculator.delete(system)
+
+
+def test_energy_zeeman_zeeman(energy_case):
+    self = energy_case
+    name = "multi_zeeman_field"
+
+    def value_fun(pos):
+        x, _, _ = pos
+        if x <= 0:
+            return (1e6, 0, 0)
         else:
-            md = self.calculator.MinDriver()
-        md.drive(system)
+            return (0, 0, 1e6)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        self.calculator.delete(system)
+    H1 = df.Field(mesh, nvdim=3, value=value_fun)
+    H2 = df.Field(mesh, nvdim=3, value=(0, 1e6, 0))
+    Ms = 1e6
 
-    def test_exchange_uniaxialanisotropy(self):
-        name = "exchange_uniaxialanisotropy"
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H1, name="zeeman1") + mm.Zeeman(H=H2, name="zeeman2")
+    system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-        A = {"r1": 1e-12, "r2": 0}
-        K = 1e5
-        u = (1, 0, 0)
-        Ms = 1e6
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    # test if it runs
 
-        system = mm.System(name=name)
-        system.energy = mm.Exchange(A=A) + mm.UniaxialAnisotropy(K=K, u=u)
-        system.m = df.Field(mesh, nvdim=3, value=(0.5, 1, 0), norm=Ms)
-
-        if hasattr(self.calculator, "RelaxDriver"):
-            system.dynamics = mm.Damping(alpha=0.5)
-            md = self.calculator.RelaxDriver()
-        else:
-            md = self.calculator.MinDriver()
-        md.drive(system)
-
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
-
-        self.calculator.delete(system)
-
-    def test_exchange_cubicanisotropy(self):
-        name = "exchange_cubicanisotropy"
-
-        A = {"r1": 1e-12, "r2": 0}
-        K = 1e5
-        u1 = (1, 0, 0)
-        u2 = (0, 1, 0)
-        Ms = 1e6
-
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-
-        system = mm.System(name=name)
-        system.energy = mm.Exchange(A=A) + mm.CubicAnisotropy(K=K, u1=u1, u2=u2)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
-
-        md = self.calculator.MinDriver()
-        md.drive(system)
-
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
-
-        self.calculator.delete(system)
-
-    def test_exchange_dmi_zeeman(self):
-        name = "exchange_dmi_zeeman"
-
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-
-        # Very weak DMI and strong Zeeman to make the final
-        # magnetisation uniform.
-        A = {"r1": 1e-12, "r2": 3e-12, "r1:r2": 2e-12}
-        D = {"r1": 1e-9, "r2": 0, "r1:r2": 5e-9}
-        H = df.Field(mesh, nvdim=3, value=(1e10, 0, 0))
-        Ms = 1e6
-
-        system = mm.System(name=name)
-        system.energy = (
-            mm.Exchange(A=A) + mm.DMI(D=D, crystalclass="Cnv_z") + mm.Zeeman(H=H)
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
-
-        md = self.calculator.MinDriver()
-        md.drive(system)
-
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1
-
-        self.calculator.delete(system)
-
-    def test_exchange_dmi_zeeman_uniaxialanisotropy_demag(self):
-        name = "exchange_dmi_zeeman_uniaxialanisotropy"
-
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-
-        # Very weak DMI and strong Zeeman to make the final
-        # magnetisation uniform.
-        A = {"r1": 1e-12, "r2": 3e-12, "r1:r2": 2e-12}
-        D = {"r1": 1e-9, "r2": 0, "r1:r2": 5e-9}  # Very weak DMI
-        H = df.Field(mesh, nvdim=3, value=(1e12, 0, 0))
-        K = 1e6
-        u = (1, 0, 0)
-        Ms = 1e5
-
-        system = mm.System(name=name)
-        system.energy = (
-            mm.Exchange(A=A)
-            + mm.DMI(D=D, crystalclass="Cnv_z")
-            + mm.UniaxialAnisotropy(K=K, u=u)
-            + mm.Zeeman(H=H)
-            + mm.Demag()
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0.3, 0), norm=Ms)
-
-        md = self.calculator.MinDriver()
-        md.drive(system)
-
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1
-
-        self.calculator.delete(system)
-
-    def test_zeeman_zeeman(self):
-        name = "multi_zeeman_field"
-
-        def value_fun(pos):
-            x, _, _ = pos
-            if x <= 0:
-                return (1e6, 0, 0)
-            else:
-                return (0, 0, 1e6)
-
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-
-        H1 = df.Field(mesh, nvdim=3, value=value_fun)
-        H2 = df.Field(mesh, nvdim=3, value=(0, 1e6, 0))
-        Ms = 1e6
-
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H1, name="zeeman1") + mm.Zeeman(
-            H=H2, name="zeeman2"
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
-
-        md = self.calculator.MinDriver()
-        md.drive(system)
-
-        # test if it runs
-
-        self.calculator.delete(system)
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/exchange.py
+++ b/micromagnetictests/calculatortests/exchange.py
@@ -1,105 +1,114 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestExchange:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def exchange_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, -5e-9, -3e-9)
+    p2 = (5e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.n = (10, 10, 6)
+    case.subregions = {
+        "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-5e-9, -5e-9, -3e-9)
-        p2 = (5e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.n = (10, 10, 6)
-        self.subregions = {
-            "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def m_init(self, pos):
-        x, y, z = pos
-        if y <= 0:
-            return (0, 0.2, 1)
-        else:
-            return (0, -0.7, -0.4)
 
-    def test_scalar(self):
-        name = "exchange_scalar"
+def m_init(pos):
+    x, y, z = pos
+    if y <= 0:
+        return (0, 0.2, 1)
+    else:
+        return (0, -0.7, -0.4)
 
-        A = 1e-12
-        Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.Exchange(A=A)
+def test_exchange_scalar(exchange_case):
+    self = exchange_case
+    name = "exchange_scalar"
 
-        mesh = df.Mesh(region=self.region, n=self.n)
-        system.m = df.Field(mesh, nvdim=3, value=self.m_init, norm=Ms)
+    A = 1e-12
+    Ms = 1e6
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system = mm.System(name=name)
+    system.energy = mm.Exchange(A=A)
 
-        assert abs(np.linalg.norm(system.m.mean()) - Ms) < 1
+    mesh = df.Mesh(region=self.region, n=self.n)
+    system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-        self.calculator.delete(system)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-    def test_dict(self):
-        name = "exchange_dict"
+    assert abs(np.linalg.norm(system.m.mean()) - Ms) < 1
 
-        A = {"r1": 3e-12, "r2": 1e-12, "r1:r2": -1e-12}
-        Ms = 1e6
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.Exchange(A=A)
 
-        mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=self.m_init, norm=Ms)
+def test_exchange_dict(exchange_case):
+    self = exchange_case
+    name = "exchange_dict"
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    A = {"r1": 3e-12, "r2": 1e-12, "r1:r2": -1e-12}
+    Ms = 1e6
 
-        # r1
-        assert abs(np.linalg.norm(system.m["r1"].mean()) - Ms) < 1
-        # r2
-        assert abs(np.linalg.norm(system.m["r2"].mean()) - Ms) < 1
+    system = mm.System(name=name)
+    system.energy = mm.Exchange(A=A)
 
-        assert (
-            abs(
-                np.dot(
-                    system.m["r1"].orientation.mean(),
-                    system.m["r2"].orientation.mean(),
-                )
-                - (-1)
+    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    # r1
+    assert abs(np.linalg.norm(system.m["r1"].mean()) - Ms) < 1
+    # r2
+    assert abs(np.linalg.norm(system.m["r2"].mean()) - Ms) < 1
+
+    assert (
+        abs(
+            np.dot(
+                system.m["r1"].orientation.mean(),
+                system.m["r2"].orientation.mean(),
             )
-            < 1e-3
+            - (-1)
         )
+        < 1e-3
+    )
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)
 
-    def test_field(self):
-        name = "exchange_field"
 
-        def A_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return 1e-10  # for 0, OOMMF gives nan
-            else:
-                return 1e-12
+def test_exchange_field(exchange_case):
+    self = exchange_case
+    name = "exchange_field"
 
-        mesh = df.Mesh(region=self.region, n=self.n)
-        A = df.Field(mesh, nvdim=1, value=A_fun)
-        Ms = 1e6
+    def A_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return 1e-10  # for 0, OOMMF gives nan
+        else:
+            return 1e-12
 
-        system = mm.System(name=name)
-        system.energy = mm.Exchange(A=A)
+    mesh = df.Mesh(region=self.region, n=self.n)
+    A = df.Field(mesh, nvdim=1, value=A_fun)
+    Ms = 1e6
 
-        system.m = df.Field(mesh, nvdim=3, value=self.m_init, norm=Ms)
+    system = mm.System(name=name)
+    system.energy = mm.Exchange(A=A)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-        assert abs(np.linalg.norm(system.m.mean()) - Ms) < 1
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    assert abs(np.linalg.norm(system.m.mean()) - Ms) < 1
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/exchange.py
+++ b/micromagnetictests/calculatortests/exchange.py
@@ -31,7 +31,6 @@ def m_init(pos):
 
 
 def test_exchange_scalar(exchange_case):
-    self = exchange_case
     name = "exchange_scalar"
 
     A = 1e-12
@@ -40,19 +39,18 @@ def test_exchange_scalar(exchange_case):
     system = mm.System(name=name)
     system.energy = mm.Exchange(A=A)
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=exchange_case.region, n=exchange_case.n)
     system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = exchange_case.calculator.MinDriver()
     md.drive(system)
 
     assert abs(np.linalg.norm(system.m.mean()) - Ms) < 1
 
-    self.calculator.delete(system)
+    exchange_case.calculator.delete(system)
 
 
 def test_exchange_dict(exchange_case):
-    self = exchange_case
     name = "exchange_dict"
 
     A = {"r1": 3e-12, "r2": 1e-12, "r1:r2": -1e-12}
@@ -61,10 +59,14 @@ def test_exchange_dict(exchange_case):
     system = mm.System(name=name)
     system.energy = mm.Exchange(A=A)
 
-    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=exchange_case.region,
+        n=exchange_case.n,
+        subregions=exchange_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = exchange_case.calculator.MinDriver()
     md.drive(system)
 
     # r1
@@ -83,11 +85,10 @@ def test_exchange_dict(exchange_case):
         < 1e-3
     )
 
-    self.calculator.delete(system)
+    exchange_case.calculator.delete(system)
 
 
 def test_exchange_field(exchange_case):
-    self = exchange_case
     name = "exchange_field"
 
     def A_fun(pos):
@@ -97,7 +98,7 @@ def test_exchange_field(exchange_case):
         else:
             return 1e-12
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=exchange_case.region, n=exchange_case.n)
     A = df.Field(mesh, nvdim=1, value=A_fun)
     Ms = 1e6
 
@@ -106,9 +107,9 @@ def test_exchange_field(exchange_case):
 
     system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = exchange_case.calculator.MinDriver()
     md.drive(system)
 
     assert abs(np.linalg.norm(system.m.mean()) - Ms) < 1
 
-    self.calculator.delete(system)
+    exchange_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/fixedsubregions.py
+++ b/micromagnetictests/calculatortests/fixedsubregions.py
@@ -1,41 +1,45 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestFixedSubregions:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def fixed_subregions_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-10e-9, -5e-9, -3e-9)
+    p2 = (10e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.subregions = {
+        "r1": df.Region(p1=(-10e-9, -5e-9, -3e-9), p2=(10e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-10e-9, 0, -3e-9), p2=(10e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-10e-9, -5e-9, -3e-9)
-        p2 = (10e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.subregions = {
-            "r1": df.Region(p1=(-10e-9, -5e-9, -3e-9), p2=(10e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-10e-9, 0, -3e-9), p2=(10e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def test_fixed_subregions(self):
-        name = "fixed_subregions"
 
-        H = (0, 0, 1e5)
-        Ms = 1e6
+def test_fixed_subregions_fixed_subregions(fixed_subregions_case):
+    self = fixed_subregions_case
+    name = "fixed_subregions"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
+    H = (0, 0, 1e5)
+    Ms = 1e6
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
 
-        md = self.calculator.MinDriver()
-        md.drive(system, fixed_subregions=["r1"])
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-        assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
+    md = self.calculator.MinDriver()
+    md.drive(system, fixed_subregions=["r1"])
 
-        assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
+    assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
 
-        self.calculator.delete(system)
+    assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/fixedsubregions.py
+++ b/micromagnetictests/calculatortests/fixedsubregions.py
@@ -23,7 +23,6 @@ def fixed_subregions_case(calculator):
 
 
 def test_fixed_subregions_fixed_subregions(fixed_subregions_case):
-    self = fixed_subregions_case
     name = "fixed_subregions"
 
     H = (0, 0, 1e5)
@@ -32,14 +31,18 @@ def test_fixed_subregions_fixed_subregions(fixed_subregions_case):
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=fixed_subregions_case.region,
+        cell=fixed_subregions_case.cell,
+        subregions=fixed_subregions_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = fixed_subregions_case.calculator.MinDriver()
     md.drive(system, fixed_subregions=["r1"])
 
     assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
 
     assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
 
-    self.calculator.delete(system)
+    fixed_subregions_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/mesh.py
+++ b/micromagnetictests/calculatortests/mesh.py
@@ -1,104 +1,114 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestMesh:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def mesh_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-7e-9, -5e-9, -4e-9)
+    p2 = (7e-9, 5e-9, 4e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.bc = "xyz"
+    case.subregions = {
+        "r1": df.Region(p1=(-7e-9, -5e-9, -4e-9), p2=(7e-9, 0, 4e-9)),
+        "r2": df.Region(p1=(-7e-9, 0, -4e-9), p2=(7e-9, 2e-9, 4e-9)),
+        "r3": df.Region(p1=(-7e-9, 2e-9, -4e-9), p2=(7e-9, 5e-9, 4e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-7e-9, -5e-9, -4e-9)
-        p2 = (7e-9, 5e-9, 4e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.bc = "xyz"
-        self.subregions = {
-            "r1": df.Region(p1=(-7e-9, -5e-9, -4e-9), p2=(7e-9, 0, 4e-9)),
-            "r2": df.Region(p1=(-7e-9, 0, -4e-9), p2=(7e-9, 2e-9, 4e-9)),
-            "r3": df.Region(p1=(-7e-9, 2e-9, -4e-9), p2=(7e-9, 5e-9, 4e-9)),
-        }
+    return case
 
-    def test_single_nopbc(self):
-        name = "mesh_single_nopbc"
 
-        Ms = 1e6
-        H = (0, 0, 5e6)
+def test_mesh_single_nopbc(mesh_case):
+    self = mesh_case
+    name = "mesh_single_nopbc"
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+    Ms = 1e6
+    H = (0, 0, 5e6)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    def test_multi_nopbc(self):
-        name = "mesh_multi_nopbc"
+    self.calculator.delete(system)
 
-        Ms = 1e6
-        H = (0, 0, 5e6)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+def test_mesh_multi_nopbc(mesh_case):
+    self = mesh_case
+    name = "mesh_multi_nopbc"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+    Ms = 1e6
+    H = (0, 0, 5e6)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-        self.calculator.delete(system)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-    def test_single_pbc(self):
-        name = "mesh_single_pbc"
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        Ms = 1e6
-        H = (0, 0, 5e6)
+    self.calculator.delete(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, bc=self.bc)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+def test_mesh_single_pbc(mesh_case):
+    self = mesh_case
+    name = "mesh_single_pbc"
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    Ms = 1e6
+    H = (0, 0, 5e6)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell, bc=self.bc)
 
-        self.calculator.delete(system)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-    def test_multi_pbc(self):
-        name = "mesh_multi_pbc"
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        Ms = 1e6
-        H = (0, 0, 5e6)
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        mesh = df.Mesh(
-            region=self.region, cell=self.cell, bc=self.bc, subregions=self.subregions
-        )
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+def test_mesh_multi_pbc(mesh_case):
+    self = mesh_case
+    name = "mesh_multi_pbc"
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    Ms = 1e6
+    H = (0, 0, 5e6)
 
-        self.calculator.delete(system)
+    mesh = df.Mesh(
+        region=self.region, cell=self.cell, bc=self.bc, subregions=self.subregions
+    )
+
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/mesh.py
+++ b/micromagnetictests/calculatortests/mesh.py
@@ -25,90 +25,91 @@ def mesh_case(calculator):
 
 
 def test_mesh_single_nopbc(mesh_case):
-    self = mesh_case
     name = "mesh_single_nopbc"
 
     Ms = 1e6
     H = (0, 0, 5e6)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=mesh_case.region, cell=mesh_case.cell)
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = mesh_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    mesh_case.calculator.delete(system)
 
 
 def test_mesh_multi_nopbc(mesh_case):
-    self = mesh_case
     name = "mesh_multi_nopbc"
 
     Ms = 1e6
     H = (0, 0, 5e6)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-
-    system = mm.System(name=name)
-    system.energy = mm.Zeeman(H=H)
-    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
-
-    md = self.calculator.MinDriver()
-    md.drive(system)
-
-    value = system.m(mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
-
-    self.calculator.delete(system)
-
-
-def test_mesh_single_pbc(mesh_case):
-    self = mesh_case
-    name = "mesh_single_pbc"
-
-    Ms = 1e6
-    H = (0, 0, 5e6)
-
-    mesh = df.Mesh(region=self.region, cell=self.cell, bc=self.bc)
-
-    system = mm.System(name=name)
-    system.energy = mm.Zeeman(H=H)
-    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
-
-    md = self.calculator.MinDriver()
-    md.drive(system)
-
-    value = system.m(mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
-
-    self.calculator.delete(system)
-
-
-def test_mesh_multi_pbc(mesh_case):
-    self = mesh_case
-    name = "mesh_multi_pbc"
-
-    Ms = 1e6
-    H = (0, 0, 5e6)
-
     mesh = df.Mesh(
-        region=self.region, cell=self.cell, bc=self.bc, subregions=self.subregions
+        region=mesh_case.region, cell=mesh_case.cell, subregions=mesh_case.subregions
     )
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = mesh_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    mesh_case.calculator.delete(system)
+
+
+def test_mesh_single_pbc(mesh_case):
+    name = "mesh_single_pbc"
+
+    Ms = 1e6
+    H = (0, 0, 5e6)
+
+    mesh = df.Mesh(region=mesh_case.region, cell=mesh_case.cell, bc=mesh_case.bc)
+
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+
+    md = mesh_case.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+
+    mesh_case.calculator.delete(system)
+
+
+def test_mesh_multi_pbc(mesh_case):
+    name = "mesh_multi_pbc"
+
+    Ms = 1e6
+    H = (0, 0, 5e6)
+
+    mesh = df.Mesh(
+        region=mesh_case.region,
+        cell=mesh_case.cell,
+        bc=mesh_case.bc,
+        subregions=mesh_case.subregions,
+    )
+
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 0, 0), norm=Ms)
+
+    md = mesh_case.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+
+    mesh_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/mindriver.py
+++ b/micromagnetictests/calculatortests/mindriver.py
@@ -27,86 +27,81 @@ def min_driver_case(calculator):
 
 
 def test_min_driver_noevolver_nodriver(min_driver_case):
-    self = min_driver_case
     name = "mindriver_noevolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.m = self.m
+    system.energy = min_driver_case.energy
+    system.m = min_driver_case.m
 
-    md = self.calculator.MinDriver()
+    md = min_driver_case.calculator.MinDriver()
     md.drive(system)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-2
+    value = system.m(min_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, min_driver_case.Ms))) < 1e-2
 
     assert system.table.x == md._x
 
-    self.calculator.delete(system)
+    min_driver_case.calculator.delete(system)
 
 
 def test_min_driver_evolver_nodriver(min_driver_case):
-    self = min_driver_case
     name = "mindriver_evolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.m = self.m
+    system.energy = min_driver_case.energy
+    system.m = min_driver_case.m
 
-    evolver = self.calculator.CGEvolver(method="Polak-Ribiere")
-    md = self.calculator.MinDriver(evolver=evolver)
+    evolver = min_driver_case.calculator.CGEvolver(method="Polak-Ribiere")
+    md = min_driver_case.calculator.MinDriver(evolver=evolver)
     md.drive(system)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+    value = system.m(min_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, min_driver_case.Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    min_driver_case.calculator.delete(system)
 
 
 def test_min_driver_noevolver_driver(min_driver_case):
-    self = min_driver_case
     name = "mindriver_noevolver_driver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.m = self.m
+    system.energy = min_driver_case.energy
+    system.m = min_driver_case.m
 
-    md = self.calculator.MinDriver(stopping_mxHxm=0.1)
+    md = min_driver_case.calculator.MinDriver(stopping_mxHxm=0.1)
     md.drive(system)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+    value = system.m(min_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, min_driver_case.Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    min_driver_case.calculator.delete(system)
 
 
 def test_min_driver_evolver_driver(min_driver_case):
-    self = min_driver_case
     name = "mindriver_evolver_driver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.m = self.m
+    system.energy = min_driver_case.energy
+    system.m = min_driver_case.m
 
-    evolver = self.calculator.CGEvolver(method="Polak-Ribiere")
-    md = self.calculator.MinDriver(evolver=evolver, stopping_mxHxm=0.1)
+    evolver = min_driver_case.calculator.CGEvolver(method="Polak-Ribiere")
+    md = min_driver_case.calculator.MinDriver(evolver=evolver, stopping_mxHxm=0.1)
     md.drive(system)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+    value = system.m(min_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, min_driver_case.Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    min_driver_case.calculator.delete(system)
 
 
 def test_min_driver_output_files(min_driver_case):
-    self = min_driver_case
     name = "mindriver_output_files"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.m = self.m
+    system.energy = min_driver_case.energy
+    system.m = min_driver_case.m
 
-    md = self.calculator.MinDriver()
+    md = min_driver_case.calculator.MinDriver()
     md.drive(system, save=True, overwrite=True)
 
     dirname = os.path.join(f"{name}", f"drive-{system.drive_number - 1}")
@@ -129,26 +124,24 @@ def test_min_driver_output_files(min_driver_case):
         omffilename = os.path.join(dirname, "m0.omf")
         assert omffilename in omf_files
 
-    self.calculator.delete(system)
+    min_driver_case.calculator.delete(system)
 
 
 def test_min_driver_wrong_evolver(min_driver_case):
-    self = min_driver_case
     system = mm.examples.macrospin()
-    evolver = self.calculator.RungeKuttaEvolver()
-    md = self.calculator.MinDriver(evolver=evolver)
+    evolver = min_driver_case.calculator.RungeKuttaEvolver()
+    md = min_driver_case.calculator.MinDriver(evolver=evolver)
 
     with pytest.raises(TypeError):
         md.drive(system)
 
-    self.calculator.delete(system)
+    min_driver_case.calculator.delete(system)
 
 
 def test_min_driver_check_for_energy(min_driver_case):
-    self = min_driver_case
     system = mm.examples.macrospin()
     system.energy = 0
-    md = self.calculator.MinDriver()
+    md = min_driver_case.calculator.MinDriver()
 
     with pytest.raises(RuntimeError, match="System's energy is not defined"):
         md.drive(system)

--- a/micromagnetictests/calculatortests/mindriver.py
+++ b/micromagnetictests/calculatortests/mindriver.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from types import SimpleNamespace
 
 import discretisedfield as df
 import micromagneticmodel as mm
@@ -7,133 +8,147 @@ import numpy as np
 import pytest
 
 
-class TestMinDriver:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def min_driver_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (0, 0, 0)
+    p2 = (5e-9, 5e-9, 5e-9)
+    n = (5, 5, 5)
+    case.Ms = 1e6
+    A = 1e-12
+    H = (0, 0, 1e6)
+    region = df.Region(p1=p1, p2=p2)
+    case.mesh = df.Mesh(region=region, n=n)
+    case.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
+    case.m = df.Field(case.mesh, nvdim=3, value=(0, 1, 0), norm=case.Ms)
 
-    def setup_method(self):
-        p1 = (0, 0, 0)
-        p2 = (5e-9, 5e-9, 5e-9)
-        n = (5, 5, 5)
-        self.Ms = 1e6
-        A = 1e-12
-        H = (0, 0, 1e6)
-        region = df.Region(p1=p1, p2=p2)
-        self.mesh = df.Mesh(region=region, n=n)
-        self.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
-        self.m = df.Field(self.mesh, nvdim=3, value=(0, 1, 0), norm=self.Ms)
+    return case
 
-    def test_noevolver_nodriver(self):
-        name = "mindriver_noevolver_nodriver"
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
+def test_min_driver_noevolver_nodriver(min_driver_case):
+    self = min_driver_case
+    name = "mindriver_noevolver_nodriver"
 
-        md = self.calculator.MinDriver()
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.m = self.m
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-2
+
+    assert system.table.x == md._x
+
+    self.calculator.delete(system)
+
+
+def test_min_driver_evolver_nodriver(min_driver_case):
+    self = min_driver_case
+    name = "mindriver_evolver_nodriver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.m = self.m
+
+    evolver = self.calculator.CGEvolver(method="Polak-Ribiere")
+    md = self.calculator.MinDriver(evolver=evolver)
+    md.drive(system)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+
+    self.calculator.delete(system)
+
+
+def test_min_driver_noevolver_driver(min_driver_case):
+    self = min_driver_case
+    name = "mindriver_noevolver_driver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.m = self.m
+
+    md = self.calculator.MinDriver(stopping_mxHxm=0.1)
+    md.drive(system)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+
+    self.calculator.delete(system)
+
+
+def test_min_driver_evolver_driver(min_driver_case):
+    self = min_driver_case
+    name = "mindriver_evolver_driver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.m = self.m
+
+    evolver = self.calculator.CGEvolver(method="Polak-Ribiere")
+    md = self.calculator.MinDriver(evolver=evolver, stopping_mxHxm=0.1)
+    md.drive(system)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
+
+    self.calculator.delete(system)
+
+
+def test_min_driver_output_files(min_driver_case):
+    self = min_driver_case
+    name = "mindriver_output_files"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.m = self.m
+
+    md = self.calculator.MinDriver()
+    md.drive(system, save=True, overwrite=True)
+
+    dirname = os.path.join(f"{name}", f"drive-{system.drive_number - 1}")
+    assert os.path.exists(dirname)
+    if os.path.exists(os.path.join(dirname, f"{name}.out")):
+        mumax3_path = os.path.join(dirname, f"{name}.out")
+        mx3filename = os.path.join(dirname, f"{name}.mx3")
+        assert os.path.isfile(mx3filename)
+        omffilename = os.path.join(dirname, "m0.omf")
+        assert os.path.isfile(omffilename)
+        omf_files = list(glob.iglob(os.path.join(mumax3_path, "*.ovf")))
+        assert len(omf_files) == 1
+    else:
+        miffilename = os.path.join(dirname, f"{name}.mif")
+        assert os.path.isfile(miffilename)
+        omf_files = list(glob.iglob(os.path.join(dirname, "*.omf")))
+        assert len(omf_files) == 2
+        odt_files = list(glob.iglob(os.path.join(dirname, "*.odt")))
+        assert len(odt_files) == 1
+        omffilename = os.path.join(dirname, "m0.omf")
+        assert omffilename in omf_files
+
+    self.calculator.delete(system)
+
+
+def test_min_driver_wrong_evolver(min_driver_case):
+    self = min_driver_case
+    system = mm.examples.macrospin()
+    evolver = self.calculator.RungeKuttaEvolver()
+    md = self.calculator.MinDriver(evolver=evolver)
+
+    with pytest.raises(TypeError):
         md.drive(system)
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-2
+    self.calculator.delete(system)
 
-        assert system.table.x == md._x
 
-        self.calculator.delete(system)
+def test_min_driver_check_for_energy(min_driver_case):
+    self = min_driver_case
+    system = mm.examples.macrospin()
+    system.energy = 0
+    md = self.calculator.MinDriver()
 
-    def test_evolver_nodriver(self):
-        name = "mindriver_evolver_nodriver"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
-
-        evolver = self.calculator.CGEvolver(method="Polak-Ribiere")
-        md = self.calculator.MinDriver(evolver=evolver)
+    with pytest.raises(RuntimeError, match="System's energy is not defined"):
         md.drive(system)
-
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
-
-        self.calculator.delete(system)
-
-    def test_noevolver_driver(self):
-        name = "mindriver_noevolver_driver"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
-
-        md = self.calculator.MinDriver(stopping_mxHxm=0.1)
-        md.drive(system)
-
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
-
-        self.calculator.delete(system)
-
-    def test_evolver_driver(self):
-        name = "mindriver_evolver_driver"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
-
-        evolver = self.calculator.CGEvolver(method="Polak-Ribiere")
-        md = self.calculator.MinDriver(evolver=evolver, stopping_mxHxm=0.1)
-        md.drive(system)
-
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1e-3
-
-        self.calculator.delete(system)
-
-    def test_output_files(self):
-        name = "mindriver_output_files"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.m = self.m
-
-        md = self.calculator.MinDriver()
-        md.drive(system, save=True, overwrite=True)
-
-        dirname = os.path.join(f"{name}", f"drive-{system.drive_number - 1}")
-        assert os.path.exists(dirname)
-        if os.path.exists(os.path.join(dirname, f"{name}.out")):
-            mumax3_path = os.path.join(dirname, f"{name}.out")
-            mx3filename = os.path.join(dirname, f"{name}.mx3")
-            assert os.path.isfile(mx3filename)
-            omffilename = os.path.join(dirname, "m0.omf")
-            assert os.path.isfile(omffilename)
-            omf_files = list(glob.iglob(os.path.join(mumax3_path, "*.ovf")))
-            assert len(omf_files) == 1
-        else:
-            miffilename = os.path.join(dirname, f"{name}.mif")
-            assert os.path.isfile(miffilename)
-            omf_files = list(glob.iglob(os.path.join(dirname, "*.omf")))
-            assert len(omf_files) == 2
-            odt_files = list(glob.iglob(os.path.join(dirname, "*.odt")))
-            assert len(odt_files) == 1
-            omffilename = os.path.join(dirname, "m0.omf")
-            assert omffilename in omf_files
-
-        self.calculator.delete(system)
-
-    def test_wrong_evolver(self):
-        system = mm.examples.macrospin()
-        evolver = self.calculator.RungeKuttaEvolver()
-        md = self.calculator.MinDriver(evolver=evolver)
-
-        with pytest.raises(TypeError):
-            md.drive(system)
-
-        self.calculator.delete(system)
-
-    def test_check_for_energy(self):
-        system = mm.examples.macrospin()
-        system.energy = 0
-        md = self.calculator.MinDriver()
-
-        with pytest.raises(RuntimeError, match="System's energy is not defined"):
-            md.drive(system)

--- a/micromagnetictests/calculatortests/precession.py
+++ b/micromagnetictests/calculatortests/precession.py
@@ -1,104 +1,112 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestPrecession:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def precession_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, -5e-9, -3e-9)
+    p2 = (5e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.n = (10, 10, 10)
+    case.subregions = {
+        "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-5e-9, -5e-9, -3e-9)
-        p2 = (5e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.n = (10, 10, 10)
-        self.subregions = {
-            "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def test_scalar(self):
-        name = "precession_scalar"
 
-        H = (0, 0, 1e6)
-        gamma0 = 0
-        Ms = 1e6
+def test_precession_scalar(precession_case):
+    self = precession_case
+    name = "precession_scalar"
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    H = (0, 0, 1e6)
+    gamma0 = 0
+    Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Precession(gamma0=gamma0)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Precession(gamma0=gamma0)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # Gamma is zero, nothing should change.
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        self.calculator.delete(system)
+    # Gamma is zero, nothing should change.
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
 
-    def test_dict(self):
-        name = "precession_dict"
+    self.calculator.delete(system)
 
-        H = (0, 0, 1e6)
-        gamma0 = {"r1": 0, "r2": 2.211e5}
-        Ms = 1e6
 
-        mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+def test_precession_dict(precession_case):
+    self = precession_case
+    name = "precession_dict"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Precession(gamma0=gamma0)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    H = (0, 0, 1e6)
+    gamma0 = {"r1": 0, "r2": 2.211e5}
+    Ms = 1e6
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
 
-        # gamma=0 region
-        value = system.m((1e-9, -4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Precession(gamma0=gamma0)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # gamma!=0 region
-        value = system.m((1e-9, 4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) > 1
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        self.calculator.delete(system)
+    # gamma=0 region
+    value = system.m((1e-9, -4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
 
-    def test_field(self):
-        name = "precession_field"
+    # gamma!=0 region
+    value = system.m((1e-9, 4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) > 1
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    self.calculator.delete(system)
 
-        def value_fun(pos):
-            x, y, z = pos
-            if y <= 0:
-                return 0
-            else:
-                return 2.211e5
 
-        H = (0, 0, 1e6)
-        gamma0 = df.Field(mesh, nvdim=1, value=value_fun)
-        Ms = 1e6
+def test_precession_field(precession_case):
+    self = precession_case
+    name = "precession_field"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Precession(gamma0=gamma0)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+    def value_fun(pos):
+        x, y, z = pos
+        if y <= 0:
+            return 0
+        else:
+            return 2.211e5
 
-        # gamma=0 region
-        value = system.m((1e-9, -4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+    H = (0, 0, 1e6)
+    gamma0 = df.Field(mesh, nvdim=1, value=value_fun)
+    Ms = 1e6
 
-        # gamma!=0 region
-        value = system.m((1e-9, 4e-9, 3e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) > 1
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Precession(gamma0=gamma0)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        self.calculator.delete(system)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
+
+    # gamma=0 region
+    value = system.m((1e-9, -4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
+
+    # gamma!=0 region
+    value = system.m((1e-9, 4e-9, 3e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) > 1
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/precession.py
+++ b/micromagnetictests/calculatortests/precession.py
@@ -23,46 +23,48 @@ def precession_case(calculator):
 
 
 def test_precession_scalar(precession_case):
-    self = precession_case
     name = "precession_scalar"
 
     H = (0, 0, 1e6)
     gamma0 = 0
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=precession_case.region, n=precession_case.n)
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.dynamics = mm.Precession(gamma0=gamma0)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = precession_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # Gamma is zero, nothing should change.
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    precession_case.calculator.delete(system)
 
 
 def test_precession_dict(precession_case):
-    self = precession_case
     name = "precession_dict"
 
     H = (0, 0, 1e6)
     gamma0 = {"r1": 0, "r2": 2.211e5}
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=precession_case.region,
+        n=precession_case.n,
+        subregions=precession_case.subregions,
+    )
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
     system.dynamics = mm.Precession(gamma0=gamma0)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = precession_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # gamma=0 region
@@ -73,14 +75,13 @@ def test_precession_dict(precession_case):
     value = system.m((1e-9, 4e-9, 3e-9))
     assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) > 1
 
-    self.calculator.delete(system)
+    precession_case.calculator.delete(system)
 
 
 def test_precession_field(precession_case):
-    self = precession_case
     name = "precession_field"
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=precession_case.region, n=precession_case.n)
 
     def value_fun(pos):
         x, y, z = pos
@@ -98,7 +99,7 @@ def test_precession_field(precession_case):
     system.dynamics = mm.Precession(gamma0=gamma0)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = precession_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
     # gamma=0 region
@@ -109,4 +110,4 @@ def test_precession_field(precession_case):
     value = system.m((1e-9, 4e-9, 3e-9))
     assert np.linalg.norm(np.cross(value, (0, 0.1 * Ms, Ms))) > 1
 
-    self.calculator.delete(system)
+    precession_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/rkky.py
+++ b/micromagnetictests/calculatortests/rkky.py
@@ -1,63 +1,68 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestRKKY:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def rkky_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, -5e-9, -3e-9)
+    p2 = (5e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.n = (10, 10, 6)
+    case.subregions = {
+        "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 1e-9, 3e-9)),
+        "r3": df.Region(p1=(-5e-9, 1e-9, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-5e-9, -5e-9, -3e-9)
-        p2 = (5e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.n = (10, 10, 6)
-        self.subregions = {
-            "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 1e-9, 3e-9)),
-            "r3": df.Region(p1=(-5e-9, 1e-9, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def m_init(self, pos):
-        x, y, z = pos
-        if y <= 0:
-            return (0, 0.2, 1)
-        else:
-            return (0, -0.5, -1)
 
-    def test_scalar(self):
-        name = "rkky_scalar"
+def m_init(pos):
+    x, y, z = pos
+    if y <= 0:
+        return (0, 0.2, 1)
+    else:
+        return (0, -0.5, -1)
 
-        sigma = -1e4
-        sigma2 = 0
-        Ms = 1e6
 
-        system = mm.System(name=name)
-        system.energy = mm.RKKY(sigma=sigma, sigma2=sigma2, subregions=["r1", "r3"])
+def test_rkky_scalar(rkky_case):
+    self = rkky_case
+    name = "rkky_scalar"
 
-        mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=self.m_init, norm=Ms)
+    sigma = -1e4
+    sigma2 = 0
+    Ms = 1e6
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    system = mm.System(name=name)
+    system.energy = mm.RKKY(sigma=sigma, sigma2=sigma2, subregions=["r1", "r3"])
 
-        # AFM
-        m1 = system.m.orientation((0, -0.5e-9, 0))
-        m2 = system.m.orientation((0, 1.5e-9, 0))
-        assert abs(np.dot(m1, m2) - (-1)) < 1e-3
+    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-        system.energy.rkky.sigma = 1e4
-        system.energy.rkky.sigma2 = 0
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        system.m = df.Field(mesh, nvdim=3, value=self.m_init, norm=Ms)
+    # AFM
+    m1 = system.m.orientation((0, -0.5e-9, 0))
+    m2 = system.m.orientation((0, 1.5e-9, 0))
+    assert abs(np.dot(m1, m2) - (-1)) < 1e-3
 
-        md.drive(system)
+    system.energy.rkky.sigma = 1e4
+    system.energy.rkky.sigma2 = 0
 
-        # FM
-        m1 = system.m.orientation((0, -0.5e-9, 0))
-        m2 = system.m.orientation((0, 1.5e-9, 0))
-        assert abs(np.dot(m1, m2) - 1) < 1e-3
+    system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-        self.calculator.delete(system)
+    md.drive(system)
+
+    # FM
+    m1 = system.m.orientation((0, -0.5e-9, 0))
+    m2 = system.m.orientation((0, 1.5e-9, 0))
+    assert abs(np.dot(m1, m2) - 1) < 1e-3
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/rkky.py
+++ b/micromagnetictests/calculatortests/rkky.py
@@ -32,7 +32,6 @@ def m_init(pos):
 
 
 def test_rkky_scalar(rkky_case):
-    self = rkky_case
     name = "rkky_scalar"
 
     sigma = -1e4
@@ -42,10 +41,12 @@ def test_rkky_scalar(rkky_case):
     system = mm.System(name=name)
     system.energy = mm.RKKY(sigma=sigma, sigma2=sigma2, subregions=["r1", "r3"])
 
-    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=rkky_case.region, n=rkky_case.n, subregions=rkky_case.subregions
+    )
     system.m = df.Field(mesh, nvdim=3, value=m_init, norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = rkky_case.calculator.MinDriver()
     md.drive(system)
 
     # AFM
@@ -65,4 +66,4 @@ def test_rkky_scalar(rkky_case):
     m2 = system.m.orientation((0, 1.5e-9, 0))
     assert abs(np.dot(m1, m2) - 1) < 1e-3
 
-    self.calculator.delete(system)
+    rkky_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/slonczewski.py
+++ b/micromagnetictests/calculatortests/slonczewski.py
@@ -1,266 +1,276 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestSlonczewski:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
-
-    def setup_method(self):
-        p1 = (-5e-9, -5e-9, -3e-9)
-        p2 = (5e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.n = (2, 2, 2)
-        self.subregions = {
-            "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
-        }
-
-    def test_single_values(self):
-        name = "slonczewski_scalar_values"
-
-        J = 1e12
-        mp = (1, 0, 0)
-        P = 0.4
-        Lambda = 2
-        eps_prime = 0
-        H = (0, 0, 1e6)
-        Ms = 1e6
-
-        mesh = df.Mesh(region=self.region, n=self.n)
-
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
-
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=20)
-
-        # Check if it runs.
-
-        # remove current -> needs different evolver
-        system.dynamics -= mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
-        )
-        # Damping factor is introduced because of the dynamics
-        # check function as empty system.dynamics will fail the test
-        system.dynamics += mm.Damping(alpha=1)
-
-        td.drive(system, t=0.2e-9, n=20)
-
-        # Check if it runs.
-
-        # time-dependence - function
-        def time_dep(t):
-            return np.sin(t * 1e10)
-
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
-
-        td.drive(system, t=0.2e-9, n=50)
-
-        # Check if it runs.
-
-        # time-dependence - tcl strings
-        tcl_strings = {}
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            return $total_time
-        }
-        """
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
-
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
-
-        td.drive(system, t=0.2e-9, n=50)
-
-        # Check if it runs.
-
-        self.calculator.delete(system)
-
-    def test_single_values_finite_temperature(self):
-        name = "slonczewski_scalar_values_finite_temperature"
-
-        J = 1e12
-        mp = (1, 0, 0)
-        P = 0.4
-        Lambda = 2
-        eps_prime = 0
-        H = (0, 0, 1e6)
-        Ms = 1e6
-
-        mesh = df.Mesh(region=self.region, n=self.n)
-
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
-        system.T = 10
+@pytest.fixture
+def slonczewski_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-5e-9, -5e-9, -3e-9)
+    p2 = (5e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.n = (2, 2, 2)
+    case.subregions = {
+        "r1": df.Region(p1=(-5e-9, -5e-9, -3e-9), p2=(5e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-5e-9, 0, -3e-9), p2=(5e-9, 5e-9, 3e-9)),
+    }
+
+    return case
+
+
+def test_slonczewski_single_values(slonczewski_case):
+    self = slonczewski_case
+    name = "slonczewski_scalar_values"
+
+    J = 1e12
+    mp = (1, 0, 0)
+    P = 0.4
+    Lambda = 2
+    eps_prime = 0
+    H = (0, 0, 1e6)
+    Ms = 1e6
+
+    mesh = df.Mesh(region=self.region, n=self.n)
+
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=20)
+
+    # Check if it runs.
+
+    # remove current -> needs different evolver
+    system.dynamics -= mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
+    )
+    # Damping factor is introduced because of the dynamics
+    # check function as empty system.dynamics will fail the test
+    system.dynamics += mm.Damping(alpha=1)
+
+    td.drive(system, t=0.2e-9, n=20)
 
-        evolver = self.calculator.Xf_ThermSpinXferEvolver()
-        td = self.calculator.TimeDriver(evolver=evolver)
-        td.drive(system, t=0.2e-11, n=20)
+    # Check if it runs.
+
+    # time-dependence - function
+    def time_dep(t):
+        return np.sin(t * 1e10)
+
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+
+    td.drive(system, t=0.2e-9, n=50)
 
-        # Check if it runs.
+    # Check if it runs.
+
+    # time-dependence - tcl strings
+    tcl_strings = {}
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        return $total_time
+    }
+    """
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
+
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        # time-dependence - function
-        def time_dep(t):
-            return np.sin(t * 1e10)
+    td.drive(system, t=0.2e-9, n=50)
+
+    # Check if it runs.
+
+    self.calculator.delete(system)
+
 
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+def test_slonczewski_single_values_finite_temperature(slonczewski_case):
+    self = slonczewski_case
+    name = "slonczewski_scalar_values_finite_temperature"
 
-        td.drive(system, t=0.2e-11, n=50)
-
-        # Check if it runs.
+    J = 1e12
+    mp = (1, 0, 0)
+    P = 0.4
+    Lambda = 2
+    eps_prime = 0
+    H = (0, 0, 1e6)
+    Ms = 1e6
+
+    mesh = df.Mesh(region=self.region, n=self.n)
+
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    system.T = 10
 
-        # time-dependence - tcl strings
-        tcl_strings = {}
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            return $total_time
-        }
-        """
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
+    evolver = self.calculator.Xf_ThermSpinXferEvolver()
+    td = self.calculator.TimeDriver(evolver=evolver)
+    td.drive(system, t=0.2e-11, n=20)
 
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    # Check if it runs.
 
-        td.drive(system, t=0.2e-11, n=50)
+    # time-dependence - function
+    def time_dep(t):
+        return np.sin(t * 1e10)
 
-        # Check if it runs.
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        self.calculator.delete(system)
+    td.drive(system, t=0.2e-11, n=50)
 
-    def test_dict_values(self):
-        name = "slonczewski_scalar_values"
+    # Check if it runs.
 
-        J = {"r1": 1e12, "r2": 5e12}
-        mp = {"r1": (0, 0, 1), "r2": (0, 1, 0)}
-        P = {"r1": 0.4, "r2": 0.35}
-        Lambda = {"r1": 2, "r2": 1.5}
-        eps_prime = {"r1": 0, "r2": 1}
-        H = (0, 0, 1e6)
-        Ms = 1e6
+    # time-dependence - tcl strings
+    tcl_strings = {}
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        return $total_time
+    }
+    """
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
 
-        mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    td.drive(system, t=0.2e-11, n=50)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=20)
+    # Check if it runs.
 
-        # Check if it runs.
+    self.calculator.delete(system)
 
-        # time-dependence - function
-        def time_dep(t):
-            return np.sin(t * 1e10)
 
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+def test_slonczewski_dict_values(slonczewski_case):
+    self = slonczewski_case
+    name = "slonczewski_scalar_values"
 
-        td.drive(system, t=0.2e-9, n=50)
+    J = {"r1": 1e12, "r2": 5e12}
+    mp = {"r1": (0, 0, 1), "r2": (0, 1, 0)}
+    P = {"r1": 0.4, "r2": 0.35}
+    Lambda = {"r1": 2, "r2": 1.5}
+    eps_prime = {"r1": 0, "r2": 1}
+    H = (0, 0, 1e6)
+    Ms = 1e6
 
-        # Check if it runs.
+    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
 
-        # time-dependence - tcl strings
-        tcl_strings = {}
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            return $total_time
-        }
-        """
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=20)
 
-        td.drive(system, t=0.2e-9, n=50)
+    # Check if it runs.
 
-        # Check if it runs.
+    # time-dependence - function
+    def time_dep(t):
+        return np.sin(t * 1e10)
 
-        self.calculator.delete(system)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    def test_field_values(self):
-        name = "slonczewski_scalar_values"
+    td.drive(system, t=0.2e-9, n=50)
 
-        mesh = df.Mesh(region=self.region, n=self.n)
+    # Check if it runs.
 
-        J = df.Field(mesh, nvdim=1, value=0.5e12)
-        mp = df.Field(mesh, nvdim=3, value=(1, 0, 0))
-        P = df.Field(mesh, nvdim=1, value=0.5)
-        Lambda = df.Field(mesh, nvdim=1, value=2)
-        eps_prime = df.Field(mesh, nvdim=1, value=1)
-        H = (0, 0, 1e6)
-        Ms = 1e6
+    # time-dependence - tcl strings
+    tcl_strings = {}
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        return $total_time
+    }
+    """
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=20)
+    td.drive(system, t=0.2e-9, n=50)
 
-        # Check if it runs.
+    # Check if it runs.
 
-        # time-dependence - function
-        def time_dep(t):
-            return np.sin(t * 1e10)
+    self.calculator.delete(system)
 
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        td.drive(system, t=0.2e-9, n=50)
+def test_slonczewski_field_values(slonczewski_case):
+    self = slonczewski_case
+    name = "slonczewski_scalar_values"
 
-        # Check if it runs.
+    mesh = df.Mesh(region=self.region, n=self.n)
 
-        # time-dependence - tcl strings
-        tcl_strings = {}
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            return $total_time
-        }
-        """
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
+    J = df.Field(mesh, nvdim=1, value=0.5e12)
+    mp = df.Field(mesh, nvdim=3, value=(1, 0, 0))
+    P = df.Field(mesh, nvdim=1, value=0.5)
+    Lambda = df.Field(mesh, nvdim=1, value=2)
+    eps_prime = df.Field(mesh, nvdim=1, value=1)
+    H = (0, 0, 1e6)
+    Ms = 1e6
 
-        system.dynamics = mm.Slonczewski(
-            J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
-        )
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-        td.drive(system, t=0.2e-9, n=50)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=20)
 
-        # Check if it runs.
+    # Check if it runs.
 
-        self.calculator.delete(system)
+    # time-dependence - function
+    def time_dep(t):
+        return np.sin(t * 1e10)
+
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, dt=1e-13, func=time_dep
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+
+    td.drive(system, t=0.2e-9, n=50)
+
+    # Check if it runs.
+
+    # time-dependence - tcl strings
+    tcl_strings = {}
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        return $total_time
+    }
+    """
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
+
+    system.dynamics = mm.Slonczewski(
+        J=J, mp=mp, P=P, Lambda=Lambda, eps_prime=eps_prime, tcl_strings=tcl_strings
+    )
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
+
+    td.drive(system, t=0.2e-9, n=50)
+
+    # Check if it runs.
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/slonczewski.py
+++ b/micromagnetictests/calculatortests/slonczewski.py
@@ -23,7 +23,6 @@ def slonczewski_case(calculator):
 
 
 def test_slonczewski_single_values(slonczewski_case):
-    self = slonczewski_case
     name = "slonczewski_scalar_values"
 
     J = 1e12
@@ -34,7 +33,7 @@ def test_slonczewski_single_values(slonczewski_case):
     H = (0, 0, 1e6)
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=slonczewski_case.region, n=slonczewski_case.n)
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
@@ -43,7 +42,7 @@ def test_slonczewski_single_values(slonczewski_case):
     )
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = slonczewski_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=20)
 
     # Check if it runs.
@@ -91,11 +90,10 @@ def test_slonczewski_single_values(slonczewski_case):
 
     # Check if it runs.
 
-    self.calculator.delete(system)
+    slonczewski_case.calculator.delete(system)
 
 
 def test_slonczewski_single_values_finite_temperature(slonczewski_case):
-    self = slonczewski_case
     name = "slonczewski_scalar_values_finite_temperature"
 
     J = 1e12
@@ -106,7 +104,7 @@ def test_slonczewski_single_values_finite_temperature(slonczewski_case):
     H = (0, 0, 1e6)
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=slonczewski_case.region, n=slonczewski_case.n)
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
@@ -116,8 +114,8 @@ def test_slonczewski_single_values_finite_temperature(slonczewski_case):
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
     system.T = 10
 
-    evolver = self.calculator.Xf_ThermSpinXferEvolver()
-    td = self.calculator.TimeDriver(evolver=evolver)
+    evolver = slonczewski_case.calculator.Xf_ThermSpinXferEvolver()
+    td = slonczewski_case.calculator.TimeDriver(evolver=evolver)
     td.drive(system, t=0.2e-11, n=20)
 
     # Check if it runs.
@@ -153,11 +151,10 @@ def test_slonczewski_single_values_finite_temperature(slonczewski_case):
 
     # Check if it runs.
 
-    self.calculator.delete(system)
+    slonczewski_case.calculator.delete(system)
 
 
 def test_slonczewski_dict_values(slonczewski_case):
-    self = slonczewski_case
     name = "slonczewski_scalar_values"
 
     J = {"r1": 1e12, "r2": 5e12}
@@ -168,7 +165,11 @@ def test_slonczewski_dict_values(slonczewski_case):
     H = (0, 0, 1e6)
     Ms = 1e6
 
-    mesh = df.Mesh(region=self.region, n=self.n, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=slonczewski_case.region,
+        n=slonczewski_case.n,
+        subregions=slonczewski_case.subregions,
+    )
 
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
@@ -177,7 +178,7 @@ def test_slonczewski_dict_values(slonczewski_case):
     )
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = slonczewski_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=20)
 
     # Check if it runs.
@@ -213,14 +214,13 @@ def test_slonczewski_dict_values(slonczewski_case):
 
     # Check if it runs.
 
-    self.calculator.delete(system)
+    slonczewski_case.calculator.delete(system)
 
 
 def test_slonczewski_field_values(slonczewski_case):
-    self = slonczewski_case
     name = "slonczewski_scalar_values"
 
-    mesh = df.Mesh(region=self.region, n=self.n)
+    mesh = df.Mesh(region=slonczewski_case.region, n=slonczewski_case.n)
 
     J = df.Field(mesh, nvdim=1, value=0.5e12)
     mp = df.Field(mesh, nvdim=3, value=(1, 0, 0))
@@ -237,7 +237,7 @@ def test_slonczewski_field_values(slonczewski_case):
     )
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = slonczewski_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=20)
 
     # Check if it runs.
@@ -273,4 +273,4 @@ def test_slonczewski_field_values(slonczewski_case):
 
     # Check if it runs.
 
-    self.calculator.delete(system)
+    slonczewski_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/threads.py
+++ b/micromagnetictests/calculatortests/threads.py
@@ -27,25 +27,24 @@ def threads_case(calculator):
 
 
 def test_threads_threads(threads_case):
-    self = threads_case
     name = "timedriver_noevolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = threads_case.energy
+    system.dynamics = threads_case.precession + threads_case.damping
+    system.m = threads_case.m
 
     # One thread
-    td = self.calculator.TimeDriver()
+    td = threads_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50, n_threads=1)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    value = system.m(threads_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, threads_case.Ms))) < 1
 
     # Two threads
     td.drive(system, t=0.2e-9, n=50, n_threads=2)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    value = system.m(threads_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, threads_case.Ms))) < 1
 
-    self.calculator.delete(system)
+    threads_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/threads.py
+++ b/micromagnetictests/calculatortests/threads.py
@@ -1,47 +1,51 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestThreads:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def threads_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (0, 0, 0)
+    p2 = (5e-9, 5e-9, 5e-9)
+    n = (2, 2, 2)
+    case.Ms = 1e6
+    A = 1e-12
+    H = (0, 0, 1e6)
+    region = df.Region(p1=p1, p2=p2)
+    case.mesh = df.Mesh(region=region, n=n)
+    case.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
+    case.precession = mm.Precession(gamma0=mm.consts.gamma0)
+    case.damping = mm.Damping(alpha=1)
+    case.m = df.Field(case.mesh, nvdim=3, value=(0, 0.1, 1), norm=case.Ms)
 
-    def setup_method(self):
-        p1 = (0, 0, 0)
-        p2 = (5e-9, 5e-9, 5e-9)
-        n = (2, 2, 2)
-        self.Ms = 1e6
-        A = 1e-12
-        H = (0, 0, 1e6)
-        region = df.Region(p1=p1, p2=p2)
-        self.mesh = df.Mesh(region=region, n=n)
-        self.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
-        self.precession = mm.Precession(gamma0=mm.consts.gamma0)
-        self.damping = mm.Damping(alpha=1)
-        self.m = df.Field(self.mesh, nvdim=3, value=(0, 0.1, 1), norm=self.Ms)
+    return case
 
-    def test_threads(self):
-        name = "timedriver_noevolver_nodriver"
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
+def test_threads_threads(threads_case):
+    self = threads_case
+    name = "timedriver_noevolver_nodriver"
 
-        # One thread
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50, n_threads=1)
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    # One thread
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50, n_threads=1)
 
-        # Two threads
-        td.drive(system, t=0.2e-9, n=50, n_threads=2)
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    # Two threads
+    td.drive(system, t=0.2e-9, n=50, n_threads=2)
 
-        self.calculator.delete(system)
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/timedriver.py
+++ b/micromagnetictests/calculatortests/timedriver.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from types import SimpleNamespace
 
 import discretisedfield as df
 import micromagneticmodel as mm
@@ -7,238 +8,264 @@ import numpy as np
 import pytest
 
 
-class TestTimeDriver:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def time_driver_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (0, 0, 0)
+    p2 = (5e-9, 5e-9, 5e-9)
+    n = (2, 2, 2)
+    case.Ms = 1e6
+    A = 1e-12
+    H = (0, 0, 1e6)
+    region = df.Region(p1=p1, p2=p2)
+    case.mesh = df.Mesh(region=region, n=n)
+    case.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
+    case.precession = mm.Precession(gamma0=mm.consts.gamma0)
+    case.damping = mm.Damping(alpha=1)
+    case.m = df.Field(case.mesh, nvdim=3, value=(0, 0.1, 1), norm=case.Ms)
 
-    def setup_method(self):
-        p1 = (0, 0, 0)
-        p2 = (5e-9, 5e-9, 5e-9)
-        n = (2, 2, 2)
-        self.Ms = 1e6
-        A = 1e-12
-        H = (0, 0, 1e6)
-        region = df.Region(p1=p1, p2=p2)
-        self.mesh = df.Mesh(region=region, n=n)
-        self.energy = mm.Exchange(A=A) + mm.Zeeman(H=H)
-        self.precession = mm.Precession(gamma0=mm.consts.gamma0)
-        self.damping = mm.Damping(alpha=1)
-        self.m = df.Field(self.mesh, nvdim=3, value=(0, 0.1, 1), norm=self.Ms)
+    return case
 
-    def test_noevolver_nodriver(self):
-        name = "timedriver_noevolver_nodriver"
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
+def test_time_driver_noevolver_nodriver(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_noevolver_nodriver"
 
-        td = self.calculator.TimeDriver()
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
+
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 10
+
+    assert system.table.x == "t"
+
+    self.calculator.delete(system)
+
+
+def test_time_driver_rungekutta_evolver_nodriver(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_rungekutta_evolver_nodriver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
+
+    evolver = self.calculator.RungeKuttaEvolver(method="rkf54s")
+    td = self.calculator.TimeDriver(evolver=evolver)
+    td.drive(system, t=0.2e-9, n=50)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+
+    self.calculator.delete(system)
+
+
+def test_time_driver_euler_evolver_nodriver(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_euler_evolver_nodriver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
+
+    evolver = self.calculator.EulerEvolver(start_dm=0.02)
+    td = self.calculator.TimeDriver(evolver=evolver)
+    td.drive(system, t=0.2e-9, n=50)
+
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+
+    self.calculator.delete(system)
+
+
+def test_time_driver_theta_evolver_nodriver(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_theta_evolver_nodriver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
+    system.T = 10
+
+    evolver = self.calculator.UHH_ThetaEvolver(fixed_timestep=2e-13)
+    td = self.calculator.TimeDriver(evolver=evolver)
+    td.drive(system, t=0.2e-9, n=50)
+
+    # Check if it runs.
+
+    self.calculator.delete(system)
+
+
+def test_time_driver_therm_heun_evolver_nodriver(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_therm_heun_evolver_nodriver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
+    system.T = 10
+
+    evolver = self.calculator.Xf_ThermHeunEvolver()
+    td = self.calculator.TimeDriver(evolver=evolver)
+    td.drive(system, t=1e-11, n=1)
+
+    # Check if it runs.
+
+    self.calculator.delete(system)
+
+
+def test_time_driver_noevolver_nodriver_finite_temperature(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_therm_heun_evolver_nodriver"
+
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
+    system.T = 10
+
+    td = self.calculator.TimeDriver()
+    with pytest.raises(RuntimeError):
         td.drive(system, t=0.2e-9, n=50)
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 10
 
-        assert system.table.x == "t"
+def test_time_driver_noevolver_driver(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_noevolver_driver"
 
-        self.calculator.delete(system)
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
 
-    def test_rungekutta_evolver_nodriver(self):
-        name = "timedriver_rungekutta_evolver_nodriver"
+    td = self.calculator.TimeDriver(stopping_dm_dt=0.01)
+    td.drive(system, t=0.3e-9, n=50)
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
 
-        evolver = self.calculator.RungeKuttaEvolver(method="rkf54s")
-        td = self.calculator.TimeDriver(evolver=evolver)
-        td.drive(system, t=0.2e-9, n=50)
+    self.calculator.delete(system)
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
 
-        self.calculator.delete(system)
+def test_time_driver_noprecession(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_noprecession"
 
-    def test_euler_evolver_nodriver(self):
-        name = "timedriver_euler_evolver_nodriver"
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.damping
+    system.m = self.m
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        evolver = self.calculator.EulerEvolver(start_dm=0.02)
-        td = self.calculator.TimeDriver(evolver=evolver)
-        td.drive(system, t=0.2e-9, n=50)
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 10
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    self.calculator.delete(system)
 
-        self.calculator.delete(system)
 
-    def test_theta_evolver_nodriver(self):
-        name = "timedriver_theta_evolver_nodriver"
+def test_time_driver_nodamping(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_nodamping"
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
-        system.T = 10
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession
+    system.m = self.m
 
-        evolver = self.calculator.UHH_ThetaEvolver(fixed_timestep=2e-13)
-        td = self.calculator.TimeDriver(evolver=evolver)
-        td.drive(system, t=0.2e-9, n=50)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50)
 
-        # Check if it runs.
+    value = system.m(self.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) > 1e3
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)
 
-    def test_therm_heun_evolver_nodriver(self):
-        name = "timedriver_therm_heun_evolver_nodriver"
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
-        system.T = 10
+def test_time_driver_output_files(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_output_files"
 
-        evolver = self.calculator.Xf_ThermHeunEvolver()
-        td = self.calculator.TimeDriver(evolver=evolver)
-        td.drive(system, t=1e-11, n=1)
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
 
-        # Check if it runs.
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.2e-9, n=50, save=True, overwrite=True)
 
-        self.calculator.delete(system)
+    dirname = os.path.join(f"{name}", f"drive-{system.drive_number - 1}")
+    assert os.path.exists(dirname)
+    if os.path.exists(os.path.join(dirname, f"{name}.out")):
+        mumax3_path = os.path.join(dirname, f"{name}.out")
+        mx3filename = os.path.join(dirname, f"{name}.mx3")
+        assert os.path.isfile(mx3filename)
+        omffilename = os.path.join(dirname, "m0.omf")
+        assert os.path.isfile(omffilename)
+        omf_files = list(glob.iglob(os.path.join(mumax3_path, "*.ovf")))
+        assert len(omf_files) == 50
+    else:
+        miffilename = os.path.join(dirname, f"{name}.mif")
+        assert os.path.isfile(miffilename)
+        omf_files = list(glob.iglob(os.path.join(dirname, "*.omf")))
+        assert len(omf_files) == 51
+        odt_files = list(glob.iglob(os.path.join(dirname, "*.odt")))
+        assert len(odt_files) == 1
+        omffilename = os.path.join(dirname, "m0.omf")
+        assert omffilename in omf_files
 
-    def test_noevolver_nodriver_finite_temperature(self):
-        name = "timedriver_therm_heun_evolver_nodriver"
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
-        system.T = 10
 
-        td = self.calculator.TimeDriver()
-        with pytest.raises(RuntimeError):
-            td.drive(system, t=0.2e-9, n=50)
+def test_time_driver_drive_exception(time_driver_case):
+    self = time_driver_case
+    name = "timedriver_exception"
 
-    def test_noevolver_driver(self):
-        name = "timedriver_noevolver_driver"
+    system = mm.System(name=name)
+    system.energy = self.energy
+    system.dynamics = self.precession + self.damping
+    system.m = self.m
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
+    td = self.calculator.TimeDriver()
+    with pytest.raises(ValueError):
+        td.drive(system, t=-0.1e-9, n=10)
+    with pytest.raises(ValueError):
+        td.drive(system, t=0.1e-9, n=-10)
 
-        td = self.calculator.TimeDriver(stopping_dm_dt=0.01)
-        td.drive(system, t=0.3e-9, n=50)
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+def test_time_driver_wrong_evolver(time_driver_case):
+    self = time_driver_case
+    system = mm.examples.macrospin()
+    evolver = self.calculator.CGEvolver()
+    td = self.calculator.TimeDriver(evolver=evolver)
 
-        self.calculator.delete(system)
+    with pytest.raises(TypeError):
+        td.drive(system, t=1e-12, n=1)
 
-    def test_noprecession(self):
-        name = "timedriver_noprecession"
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.damping
-        system.m = self.m
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
+def test_time_driver_check_for_energy_and_dynamics(time_driver_case):
+    self = time_driver_case
+    system = mm.examples.macrospin()
+    system.energy = 0
+    td = self.calculator.TimeDriver()
 
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 10
+    with pytest.raises(RuntimeError, match="System's energy is not defined"):
+        td.drive(system, t=1e-12, n=1)
 
-        self.calculator.delete(system)
+    system.dynamics = 0
 
-    def test_nodamping(self):
-        name = "timedriver_nodamping"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession
-        system.m = self.m
-
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50)
-
-        value = system.m(self.mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) > 1e3
-
-        self.calculator.delete(system)
-
-    def test_output_files(self):
-        name = "timedriver_output_files"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
-
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.2e-9, n=50, save=True, overwrite=True)
-
-        dirname = os.path.join(f"{name}", f"drive-{system.drive_number - 1}")
-        assert os.path.exists(dirname)
-        if os.path.exists(os.path.join(dirname, f"{name}.out")):
-            mumax3_path = os.path.join(dirname, f"{name}.out")
-            mx3filename = os.path.join(dirname, f"{name}.mx3")
-            assert os.path.isfile(mx3filename)
-            omffilename = os.path.join(dirname, "m0.omf")
-            assert os.path.isfile(omffilename)
-            omf_files = list(glob.iglob(os.path.join(mumax3_path, "*.ovf")))
-            assert len(omf_files) == 50
-        else:
-            miffilename = os.path.join(dirname, f"{name}.mif")
-            assert os.path.isfile(miffilename)
-            omf_files = list(glob.iglob(os.path.join(dirname, "*.omf")))
-            assert len(omf_files) == 51
-            odt_files = list(glob.iglob(os.path.join(dirname, "*.odt")))
-            assert len(odt_files) == 1
-            omffilename = os.path.join(dirname, "m0.omf")
-            assert omffilename in omf_files
-
-        self.calculator.delete(system)
-
-    def test_drive_exception(self):
-        name = "timedriver_exception"
-
-        system = mm.System(name=name)
-        system.energy = self.energy
-        system.dynamics = self.precession + self.damping
-        system.m = self.m
-
-        td = self.calculator.TimeDriver()
-        with pytest.raises(ValueError):
-            td.drive(system, t=-0.1e-9, n=10)
-        with pytest.raises(ValueError):
-            td.drive(system, t=0.1e-9, n=-10)
-
-    def test_wrong_evolver(self):
-        system = mm.examples.macrospin()
-        evolver = self.calculator.CGEvolver()
-        td = self.calculator.TimeDriver(evolver=evolver)
-
-        with pytest.raises(TypeError):
-            td.drive(system, t=1e-12, n=1)
-
-        self.calculator.delete(system)
-
-    def test_check_for_energy_and_dynamics(self):
-        system = mm.examples.macrospin()
-        system.energy = 0
-        td = self.calculator.TimeDriver()
-
-        with pytest.raises(RuntimeError, match="System's energy is not defined"):
-            td.drive(system, t=1e-12, n=1)
-
-        system.dynamics = 0
-
-        with pytest.raises(RuntimeError, match="System's dynamics is not defined"):
-            td.drive(system, t=1e-12, n=1)
+    with pytest.raises(RuntimeError, match="System's dynamics is not defined"):
+        td.drive(system, t=1e-12, n=1)

--- a/micromagnetictests/calculatortests/timedriver.py
+++ b/micromagnetictests/calculatortests/timedriver.py
@@ -29,180 +29,170 @@ def time_driver_case(calculator):
 
 
 def test_time_driver_noevolver_nodriver(time_driver_case):
-    self = time_driver_case
     name = "timedriver_noevolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
 
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 10
+    value = system.m(time_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, time_driver_case.Ms))) < 10
 
     assert system.table.x == "t"
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_rungekutta_evolver_nodriver(time_driver_case):
-    self = time_driver_case
     name = "timedriver_rungekutta_evolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
 
-    evolver = self.calculator.RungeKuttaEvolver(method="rkf54s")
-    td = self.calculator.TimeDriver(evolver=evolver)
+    evolver = time_driver_case.calculator.RungeKuttaEvolver(method="rkf54s")
+    td = time_driver_case.calculator.TimeDriver(evolver=evolver)
     td.drive(system, t=0.2e-9, n=50)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    value = system.m(time_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, time_driver_case.Ms))) < 1
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_euler_evolver_nodriver(time_driver_case):
-    self = time_driver_case
     name = "timedriver_euler_evolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
 
-    evolver = self.calculator.EulerEvolver(start_dm=0.02)
-    td = self.calculator.TimeDriver(evolver=evolver)
+    evolver = time_driver_case.calculator.EulerEvolver(start_dm=0.02)
+    td = time_driver_case.calculator.TimeDriver(evolver=evolver)
     td.drive(system, t=0.2e-9, n=50)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    value = system.m(time_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, time_driver_case.Ms))) < 1
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_theta_evolver_nodriver(time_driver_case):
-    self = time_driver_case
     name = "timedriver_theta_evolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
     system.T = 10
 
-    evolver = self.calculator.UHH_ThetaEvolver(fixed_timestep=2e-13)
-    td = self.calculator.TimeDriver(evolver=evolver)
+    evolver = time_driver_case.calculator.UHH_ThetaEvolver(fixed_timestep=2e-13)
+    td = time_driver_case.calculator.TimeDriver(evolver=evolver)
     td.drive(system, t=0.2e-9, n=50)
 
     # Check if it runs.
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_therm_heun_evolver_nodriver(time_driver_case):
-    self = time_driver_case
     name = "timedriver_therm_heun_evolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
     system.T = 10
 
-    evolver = self.calculator.Xf_ThermHeunEvolver()
-    td = self.calculator.TimeDriver(evolver=evolver)
+    evolver = time_driver_case.calculator.Xf_ThermHeunEvolver()
+    td = time_driver_case.calculator.TimeDriver(evolver=evolver)
     td.drive(system, t=1e-11, n=1)
 
     # Check if it runs.
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_noevolver_nodriver_finite_temperature(time_driver_case):
-    self = time_driver_case
     name = "timedriver_therm_heun_evolver_nodriver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
     system.T = 10
 
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
     with pytest.raises(RuntimeError):
         td.drive(system, t=0.2e-9, n=50)
 
 
 def test_time_driver_noevolver_driver(time_driver_case):
-    self = time_driver_case
     name = "timedriver_noevolver_driver"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
 
-    td = self.calculator.TimeDriver(stopping_dm_dt=0.01)
+    td = time_driver_case.calculator.TimeDriver(stopping_dm_dt=0.01)
     td.drive(system, t=0.3e-9, n=50)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 1
+    value = system.m(time_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, time_driver_case.Ms))) < 1
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_noprecession(time_driver_case):
-    self = time_driver_case
     name = "timedriver_noprecession"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.damping
+    system.m = time_driver_case.m
 
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) < 10
+    value = system.m(time_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, time_driver_case.Ms))) < 10
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_nodamping(time_driver_case):
-    self = time_driver_case
     name = "timedriver_nodamping"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession
+    system.m = time_driver_case.m
 
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50)
 
-    value = system.m(self.mesh.region.center)
-    assert np.linalg.norm(np.subtract(value, (0, 0, self.Ms))) > 1e3
+    value = system.m(time_driver_case.mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, time_driver_case.Ms))) > 1e3
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_output_files(time_driver_case):
-    self = time_driver_case
     name = "timedriver_output_files"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
 
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
     td.drive(system, t=0.2e-9, n=50, save=True, overwrite=True)
 
     dirname = os.path.join(f"{name}", f"drive-{system.drive_number - 1}")
@@ -225,19 +215,18 @@ def test_time_driver_output_files(time_driver_case):
         omffilename = os.path.join(dirname, "m0.omf")
         assert omffilename in omf_files
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_drive_exception(time_driver_case):
-    self = time_driver_case
     name = "timedriver_exception"
 
     system = mm.System(name=name)
-    system.energy = self.energy
-    system.dynamics = self.precession + self.damping
-    system.m = self.m
+    system.energy = time_driver_case.energy
+    system.dynamics = time_driver_case.precession + time_driver_case.damping
+    system.m = time_driver_case.m
 
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
     with pytest.raises(ValueError):
         td.drive(system, t=-0.1e-9, n=10)
     with pytest.raises(ValueError):
@@ -245,22 +234,20 @@ def test_time_driver_drive_exception(time_driver_case):
 
 
 def test_time_driver_wrong_evolver(time_driver_case):
-    self = time_driver_case
     system = mm.examples.macrospin()
-    evolver = self.calculator.CGEvolver()
-    td = self.calculator.TimeDriver(evolver=evolver)
+    evolver = time_driver_case.calculator.CGEvolver()
+    td = time_driver_case.calculator.TimeDriver(evolver=evolver)
 
     with pytest.raises(TypeError):
         td.drive(system, t=1e-12, n=1)
 
-    self.calculator.delete(system)
+    time_driver_case.calculator.delete(system)
 
 
 def test_time_driver_check_for_energy_and_dynamics(time_driver_case):
-    self = time_driver_case
     system = mm.examples.macrospin()
     system.energy = 0
-    td = self.calculator.TimeDriver()
+    td = time_driver_case.calculator.TimeDriver()
 
     with pytest.raises(RuntimeError, match="System's energy is not defined"):
         td.drive(system, t=1e-12, n=1)

--- a/micromagnetictests/calculatortests/uniaxialanisotropy.py
+++ b/micromagnetictests/calculatortests/uniaxialanisotropy.py
@@ -23,7 +23,6 @@ def uniaxial_anisotropy_case(calculator):
 
 
 def test_uniaxial_anisotropy_scalar_vector(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_scalar_vector"
 
     K = 1e5
@@ -33,20 +32,21 @@ def test_uniaxial_anisotropy_scalar_vector(uniaxial_anisotropy_case):
     system = mm.System(name=name)
     system.energy = mm.UniaxialAnisotropy(K=K, u=u)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region, cell=uniaxial_anisotropy_case.cell
+    )
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)
 
 
 def test_uniaxial_anisotropy_field_vector(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_field_vector"
 
     def value_fun(pos):
@@ -56,7 +56,9 @@ def test_uniaxial_anisotropy_field_vector(uniaxial_anisotropy_case):
         else:
             return 1e5
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region, cell=uniaxial_anisotropy_case.cell
+    )
 
     K = df.Field(mesh, nvdim=1, value=value_fun)
     u = (0, 0, 1)
@@ -66,7 +68,7 @@ def test_uniaxial_anisotropy_field_vector(uniaxial_anisotropy_case):
     system.energy = mm.UniaxialAnisotropy(K=K, u=u)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, -2e-9, -2e-9))
@@ -75,11 +77,10 @@ def test_uniaxial_anisotropy_field_vector(uniaxial_anisotropy_case):
     value = system.m((2e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)
 
 
 def test_uniaxial_anisotropy_scalar_field(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_scalar_field"
 
     def value_fun(pos):
@@ -89,7 +90,9 @@ def test_uniaxial_anisotropy_scalar_field(uniaxial_anisotropy_case):
         else:
             return (0, 1, 0)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region, cell=uniaxial_anisotropy_case.cell
+    )
 
     K = 1e5
     u = df.Field(mesh, nvdim=3, value=value_fun)
@@ -99,7 +102,7 @@ def test_uniaxial_anisotropy_scalar_field(uniaxial_anisotropy_case):
     system.energy = mm.UniaxialAnisotropy(K=K, u=u)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, -2e-9, -2e-9))
@@ -108,11 +111,10 @@ def test_uniaxial_anisotropy_scalar_field(uniaxial_anisotropy_case):
     value = system.m((2e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)
 
 
 def test_uniaxial_anisotropy_field_field(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_field_field"
 
     def K_fun(pos):
@@ -129,7 +131,9 @@ def test_uniaxial_anisotropy_field_field(uniaxial_anisotropy_case):
         else:
             return (0, 1, 0)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region, cell=uniaxial_anisotropy_case.cell
+    )
 
     K = df.Field(mesh, nvdim=1, value=K_fun)
     u = df.Field(mesh, nvdim=3, value=u_fun)
@@ -139,7 +143,7 @@ def test_uniaxial_anisotropy_field_field(uniaxial_anisotropy_case):
     system.energy = mm.UniaxialAnisotropy(K=K, u=u)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-3e-9, -3e-9, -3e-9))
@@ -151,14 +155,17 @@ def test_uniaxial_anisotropy_field_field(uniaxial_anisotropy_case):
     value = system.m((0, 0, 0))
     assert np.linalg.norm(np.cross(value, (Ms, Ms, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)
 
 
 def test_uniaxial_anisotropy_dict_vector(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_dict_vector"
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region,
+        cell=uniaxial_anisotropy_case.cell,
+        subregions=uniaxial_anisotropy_case.subregions,
+    )
     K = {"r1": 0, "r2": 1e5}
     u = (0, 0, 1)
     Ms = 1e6
@@ -167,7 +174,7 @@ def test_uniaxial_anisotropy_dict_vector(uniaxial_anisotropy_case):
     system.energy = mm.UniaxialAnisotropy(K=K, u=u)
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, -2e-9, -2e-9))
@@ -176,11 +183,10 @@ def test_uniaxial_anisotropy_dict_vector(uniaxial_anisotropy_case):
     value = system.m((2e-9, 2e-9, 2e-9))
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)
 
 
 def test_uniaxial_anisotropy_field_dict(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_field_dict"
 
     def K_fun(pos):
@@ -197,7 +203,9 @@ def test_uniaxial_anisotropy_field_dict(uniaxial_anisotropy_case):
         else:
             return (0, 1, 0)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region, cell=uniaxial_anisotropy_case.cell
+    )
 
     K = df.Field(mesh, nvdim=1, value=K_fun)
     u = df.Field(mesh, nvdim=3, value=u_fun)
@@ -207,7 +215,7 @@ def test_uniaxial_anisotropy_field_dict(uniaxial_anisotropy_case):
     system.energy = mm.UniaxialAnisotropy(K=K, u=u)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-3e-9, -3e-9, -3e-9))
@@ -219,11 +227,10 @@ def test_uniaxial_anisotropy_field_dict(uniaxial_anisotropy_case):
     value = system.m((0, 0, 0))
     assert np.linalg.norm(np.cross(value, (Ms, Ms, 0))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)
 
 
 def test_uniaxial_anisotropy_higher_order_scalar_vector(uniaxial_anisotropy_case):
-    self = uniaxial_anisotropy_case
     name = "uniaxialanisotropy_higher_order_scalar_vector"
 
     K1 = 1e5
@@ -234,13 +241,15 @@ def test_uniaxial_anisotropy_higher_order_scalar_vector(uniaxial_anisotropy_case
     system = mm.System(name=name)
     system.energy = mm.UniaxialAnisotropy(K1=K1, K2=K2, u=u)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(
+        region=uniaxial_anisotropy_case.region, cell=uniaxial_anisotropy_case.cell
+    )
     system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = uniaxial_anisotropy_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
     assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    self.calculator.delete(system)
+    uniaxial_anisotropy_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/uniaxialanisotropy.py
+++ b/micromagnetictests/calculatortests/uniaxialanisotropy.py
@@ -1,230 +1,246 @@
+from types import SimpleNamespace
+
 import discretisedfield as df
 import micromagneticmodel as mm
 import numpy as np
 import pytest
 
 
-class TestUniaxialAnisotropy:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def uniaxial_anisotropy_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-7e-9, -5e-9, -4e-9)
+    p2 = (7e-9, 5e-9, 4e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.subregions = {
+        "r1": df.Region(p1=(-7e-9, -5e-9, -4e-9), p2=(0, 5e-9, 4e-9)),
+        "r2": df.Region(p1=(0, -5e-9, -4e-9), p2=(7e-9, 5e-9, 4e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-7e-9, -5e-9, -4e-9)
-        p2 = (7e-9, 5e-9, 4e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.subregions = {
-            "r1": df.Region(p1=(-7e-9, -5e-9, -4e-9), p2=(0, 5e-9, 4e-9)),
-            "r2": df.Region(p1=(0, -5e-9, -4e-9), p2=(7e-9, 5e-9, 4e-9)),
-        }
+    return case
 
-    def test_scalar_vector(self):
-        name = "uniaxialanisotropy_scalar_vector"
 
-        K = 1e5
-        u = (0, 0, 1)
-        Ms = 1e6
+def test_uniaxial_anisotropy_scalar_vector(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_scalar_vector"
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K=K, u=u)
+    K = 1e5
+    u = (0, 0, 1)
+    Ms = 1e6
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K=K, u=u)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-    def test_field_vector(self):
-        name = "uniaxialanisotropy_field_vector"
+    self.calculator.delete(system)
 
-        def value_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return 0
-            else:
-                return 1e5
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+def test_uniaxial_anisotropy_field_vector(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_field_vector"
 
-        K = df.Field(mesh, nvdim=1, value=value_fun)
-        u = (0, 0, 1)
-        Ms = 1e6
+    def value_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return 0
+        else:
+            return 1e5
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K=K, u=u)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    K = df.Field(mesh, nvdim=1, value=value_fun)
+    u = (0, 0, 1)
+    Ms = 1e6
 
-        value = system.m((-2e-9, -2e-9, -2e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K=K, u=u)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        self.calculator.delete(system)
+    value = system.m((-2e-9, -2e-9, -2e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
 
-    def test_scalar_field(self):
-        name = "uniaxialanisotropy_scalar_field"
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        def value_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (1, 0, 0)
-            else:
-                return (0, 1, 0)
+    self.calculator.delete(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        K = 1e5
-        u = df.Field(mesh, nvdim=3, value=value_fun)
-        Ms = 1e6
+def test_uniaxial_anisotropy_scalar_field(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_scalar_field"
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K=K, u=u)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
+    def value_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (1, 0, 0)
+        else:
+            return (0, 1, 0)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        value = system.m((-2e-9, -2e-9, -2e-9))
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+    K = 1e5
+    u = df.Field(mesh, nvdim=3, value=value_fun)
+    Ms = 1e6
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K=K, u=u)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-        self.calculator.delete(system)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-    def test_field_field(self):
-        name = "uniaxialanisotropy_field_field"
+    value = system.m((-2e-9, -2e-9, -2e-9))
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-        def K_fun(pos):
-            x, y, z = pos
-            if -2e-9 <= x <= 2e-9:
-                return 0
-            else:
-                return 1e5
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
 
-        def u_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (1, 0, 0)
-            else:
-                return (0, 1, 0)
+    self.calculator.delete(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        K = df.Field(mesh, nvdim=1, value=K_fun)
-        u = df.Field(mesh, nvdim=3, value=u_fun)
-        Ms = 1e6
+def test_uniaxial_anisotropy_field_field(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_field_field"
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K=K, u=u)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
+    def K_fun(pos):
+        x, y, z = pos
+        if -2e-9 <= x <= 2e-9:
+            return 0
+        else:
+            return 1e5
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    def u_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (1, 0, 0)
+        else:
+            return (0, 1, 0)
 
-        value = system.m((-3e-9, -3e-9, -3e-9))
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        value = system.m((3e-9, 3e-9, 3e-9))
-        assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
+    K = df.Field(mesh, nvdim=1, value=K_fun)
+    u = df.Field(mesh, nvdim=3, value=u_fun)
+    Ms = 1e6
 
-        value = system.m((0, 0, 0))
-        assert np.linalg.norm(np.cross(value, (Ms, Ms, 0))) < 1e-3
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K=K, u=u)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-        self.calculator.delete(system)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-    def test_dict_vector(self):
-        name = "uniaxialanisotropy_dict_vector"
+    value = system.m((-3e-9, -3e-9, -3e-9))
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        K = {"r1": 0, "r2": 1e5}
-        u = (0, 0, 1)
-        Ms = 1e6
+    value = system.m((3e-9, 3e-9, 3e-9))
+    assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K=K, u=u)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+    value = system.m((0, 0, 0))
+    assert np.linalg.norm(np.cross(value, (Ms, Ms, 0))) < 1e-3
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    self.calculator.delete(system)
 
-        value = system.m((-2e-9, -2e-9, -2e-9))
-        assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+def test_uniaxial_anisotropy_dict_vector(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_dict_vector"
 
-        self.calculator.delete(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    K = {"r1": 0, "r2": 1e5}
+    u = (0, 0, 1)
+    Ms = 1e6
 
-    def test_field_dict(self):
-        name = "uniaxialanisotropy_field_dict"
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K=K, u=u)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
 
-        def K_fun(pos):
-            x, y, z = pos
-            if -2e-9 <= x <= 2e-9:
-                return 0
-            else:
-                return 1e5
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        def u_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (1, 0, 0)
-            else:
-                return (0, 1, 0)
+    value = system.m((-2e-9, -2e-9, -2e-9))
+    assert np.linalg.norm(np.cross(value, (0, 0.3 * Ms, Ms))) < 1e-3
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        K = df.Field(mesh, nvdim=1, value=K_fun)
-        u = df.Field(mesh, nvdim=3, value=u_fun)
-        Ms = 1e6
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K=K, u=u)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+def test_uniaxial_anisotropy_field_dict(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_field_dict"
 
-        value = system.m((-3e-9, -3e-9, -3e-9))
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+    def K_fun(pos):
+        x, y, z = pos
+        if -2e-9 <= x <= 2e-9:
+            return 0
+        else:
+            return 1e5
 
-        value = system.m((3e-9, 3e-9, 3e-9))
-        assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
+    def u_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (1, 0, 0)
+        else:
+            return (0, 1, 0)
 
-        value = system.m((0, 0, 0))
-        assert np.linalg.norm(np.cross(value, (Ms, Ms, 0))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        self.calculator.delete(system)
+    K = df.Field(mesh, nvdim=1, value=K_fun)
+    u = df.Field(mesh, nvdim=3, value=u_fun)
+    Ms = 1e6
 
-    def test_higher_order_scalar_vector(self):
-        name = "uniaxialanisotropy_higher_order_scalar_vector"
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K=K, u=u)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 0), norm=Ms)
 
-        K1 = 1e5
-        K2 = 2e3
-        u = (0, 0, 1)
-        Ms = 1e6
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.UniaxialAnisotropy(K1=K1, K2=K2, u=u)
+    value = system.m((-3e-9, -3e-9, -3e-9))
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+    value = system.m((3e-9, 3e-9, 3e-9))
+    assert np.linalg.norm(np.subtract(value, (0, Ms, 0))) < 1e-3
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    value = system.m((0, 0, 0))
+    assert np.linalg.norm(np.cross(value, (Ms, Ms, 0))) < 1e-3
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    self.calculator.delete(system)
 
-        self.calculator.delete(system)
+
+def test_uniaxial_anisotropy_higher_order_scalar_vector(uniaxial_anisotropy_case):
+    self = uniaxial_anisotropy_case
+    name = "uniaxialanisotropy_higher_order_scalar_vector"
+
+    K1 = 1e5
+    K2 = 2e3
+    u = (0, 0, 1)
+    Ms = 1e6
+
+    system = mm.System(name=name)
+    system.energy = mm.UniaxialAnisotropy(K1=K1, K2=K2, u=u)
+
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 0.3, 1), norm=Ms)
+
+    md = self.calculator.MinDriver()
+    md.drive(system)
+
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/zeeman.py
+++ b/micromagnetictests/calculatortests/zeeman.py
@@ -24,7 +24,6 @@ def zeeman_case(calculator):
 
 
 def test_zeeman_vector(zeeman_case):
-    self = zeeman_case
     name = "zeeman_vector"
 
     H = (0, 0, 1e6)
@@ -35,10 +34,10 @@ def test_zeeman_vector(zeeman_case):
     # time-independent
     system.energy = mm.Zeeman(H=H)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = zeeman_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
@@ -46,7 +45,6 @@ def test_zeeman_vector(zeeman_case):
 
 
 def test_zeeman_time_vector(zeeman_case):
-    self = zeeman_case
     name = "zeeman_vector"
 
     H = (0, 0, 1e6)
@@ -57,10 +55,10 @@ def test_zeeman_time_vector(zeeman_case):
     # time-independent
     system.energy = mm.Zeeman(H=H)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = zeeman_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m(mesh.region.center)
@@ -71,22 +69,22 @@ def test_zeeman_time_vector(zeeman_case):
     # with empty system dynamics, error will be raised due to
     # check system dynamics.
     system.dynamics = mm.Damping(alpha=1)
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - sinc
     system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
-    self.calculator.delete(system)
+    zeeman_case.calculator.delete(system)
 
     # time-dependent - function
     def t_func(t):
@@ -99,10 +97,10 @@ def test_zeeman_time_vector(zeeman_case):
 
     system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - two terms
@@ -162,17 +160,16 @@ def test_zeeman_time_vector(zeeman_case):
 
     system.energy = mm.Zeeman(H=H, tcl_strings=tcl_strings)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
-    self.calculator.delete(system)
+    zeeman_case.calculator.delete(system)
 
 
 def test_zeeman_dict(zeeman_case):
-    self = zeeman_case
     name = "zeeman_dict"
 
     H = {"r1": (1e5, 0, 0), "r2": (0, 0, 1e5)}
@@ -181,10 +178,14 @@ def test_zeeman_dict(zeeman_case):
     system = mm.System(name=name)
     system.energy = mm.Zeeman(H=H)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=zeeman_case.region,
+        cell=zeeman_case.cell,
+        subregions=zeeman_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = zeeman_case.calculator.MinDriver()
     md.drive(system)
 
     assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
@@ -193,7 +194,6 @@ def test_zeeman_dict(zeeman_case):
 
 
 def test_zeeman_time_dict(zeeman_case):
-    self = zeeman_case
     name = "zeeman_dict"
 
     H = {"r1": (1e5, 0, 0), "r2": (0, 0, 1e5)}
@@ -205,10 +205,14 @@ def test_zeeman_time_dict(zeeman_case):
     # check system dynamics.
     system.dynamics = mm.Damping(alpha=1)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=zeeman_case.region,
+        cell=zeeman_case.cell,
+        subregions=zeeman_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = zeeman_case.calculator.MinDriver()
     md.drive(system)
 
     assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
@@ -218,19 +222,27 @@ def test_zeeman_time_dict(zeeman_case):
     # time-dependent - sin
     system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=zeeman_case.region,
+        cell=zeeman_case.cell,
+        subregions=zeeman_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - sinc
     system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=zeeman_case.region,
+        cell=zeeman_case.cell,
+        subregions=zeeman_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - function
@@ -244,17 +256,20 @@ def test_zeeman_time_dict(zeeman_case):
 
     system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    mesh = df.Mesh(
+        region=zeeman_case.region,
+        cell=zeeman_case.cell,
+        subregions=zeeman_case.subregions,
+    )
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
-    self.calculator.delete(system)
+    zeeman_case.calculator.delete(system)
 
 
 def test_zeeman_field(zeeman_case):
-    self = zeeman_case
     name = "zeeman_field"
 
     def value_fun(pos):
@@ -264,7 +279,7 @@ def test_zeeman_field(zeeman_case):
         else:
             return (0, 0, 1e6)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
 
     H = df.Field(mesh, nvdim=3, value=value_fun)
     Ms = 1e6
@@ -273,7 +288,7 @@ def test_zeeman_field(zeeman_case):
     system.energy = mm.Zeeman(H=H)
     system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = zeeman_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, -2e-9, -2e-9))
@@ -284,7 +299,6 @@ def test_zeeman_field(zeeman_case):
 
 
 def test_zeeman_time_field(zeeman_case):
-    self = zeeman_case
     name = "zeeman_field"
 
     def value_fun(pos):
@@ -294,7 +308,7 @@ def test_zeeman_time_field(zeeman_case):
         else:
             return (0, 0, 1e6)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
 
     H = df.Field(mesh, nvdim=3, value=value_fun)
     Ms = 1e6
@@ -303,7 +317,7 @@ def test_zeeman_time_field(zeeman_case):
     system.energy = mm.Zeeman(H=H)
     system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-    md = self.calculator.MinDriver()
+    md = zeeman_case.calculator.MinDriver()
     md.drive(system)
 
     value = system.m((-2e-9, -2e-9, -2e-9))
@@ -318,19 +332,19 @@ def test_zeeman_time_field(zeeman_case):
     # check system dynamics.
     system.dynamics = mm.Damping(alpha=1)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - sinc
     system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - function
@@ -350,10 +364,10 @@ def test_zeeman_time_field(zeeman_case):
 
     system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
     # time-dependent - tcl strings
@@ -379,10 +393,10 @@ def test_zeeman_time_field(zeeman_case):
 
     system.energy = mm.Zeeman(H=H, tcl_strings=tcl_strings)
 
-    mesh = df.Mesh(region=self.region, cell=self.cell)
+    mesh = df.Mesh(region=zeeman_case.region, cell=zeeman_case.cell)
     system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    td = self.calculator.TimeDriver()
+    td = zeeman_case.calculator.TimeDriver()
     td.drive(system, t=0.1e-9, n=20)
 
-    self.calculator.delete(system)
+    zeeman_case.calculator.delete(system)

--- a/micromagnetictests/calculatortests/zeeman.py
+++ b/micromagnetictests/calculatortests/zeeman.py
@@ -1,4 +1,5 @@
 import math
+from types import SimpleNamespace
 
 import discretisedfield as df
 import micromagneticmodel as mm
@@ -6,370 +7,382 @@ import numpy as np
 import pytest
 
 
-class TestZeeman:
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+@pytest.fixture
+def zeeman_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    p1 = (-10e-9, -5e-9, -3e-9)
+    p2 = (10e-9, 5e-9, 3e-9)
+    case.region = df.Region(p1=p1, p2=p2)
+    case.cell = (1e-9, 1e-9, 1e-9)
+    case.subregions = {
+        "r1": df.Region(p1=(-10e-9, -5e-9, -3e-9), p2=(10e-9, 0, 3e-9)),
+        "r2": df.Region(p1=(-10e-9, 0, -3e-9), p2=(10e-9, 5e-9, 3e-9)),
+    }
 
-    def setup_method(self):
-        p1 = (-10e-9, -5e-9, -3e-9)
-        p2 = (10e-9, 5e-9, 3e-9)
-        self.region = df.Region(p1=p1, p2=p2)
-        self.cell = (1e-9, 1e-9, 1e-9)
-        self.subregions = {
-            "r1": df.Region(p1=(-10e-9, -5e-9, -3e-9), p2=(10e-9, 0, 3e-9)),
-            "r2": df.Region(p1=(-10e-9, 0, -3e-9), p2=(10e-9, 5e-9, 3e-9)),
-        }
+    return case
 
-    def test_vector(self):
-        name = "zeeman_vector"
 
-        H = (0, 0, 1e6)
-        Ms = 1e6
+def test_zeeman_vector(zeeman_case):
+    self = zeeman_case
+    name = "zeeman_vector"
 
-        system = mm.System(name=name)
+    H = (0, 0, 1e6)
+    Ms = 1e6
 
-        # time-independent
-        system.energy = mm.Zeeman(H=H)
+    system = mm.System(name=name)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    # time-independent
+    system.energy = mm.Zeeman(H=H)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-    def test_time_vector(self):
-        name = "zeeman_vector"
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        H = (0, 0, 1e6)
-        Ms = 1e6
 
-        system = mm.System(name=name)
+def test_zeeman_time_vector(zeeman_case):
+    self = zeeman_case
+    name = "zeeman_vector"
 
-        # time-independent
-        system.energy = mm.Zeeman(H=H)
+    H = (0, 0, 1e6)
+    Ms = 1e6
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    system = mm.System(name=name)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    # time-independent
+    system.energy = mm.Zeeman(H=H)
 
-        value = system.m(mesh.region.center)
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        # time-dependent - sin
-        system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
-        # with empty system dynamics, error will be raised due to
-        # check system dynamics.
-        system.dynamics = mm.Damping(alpha=1)
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    value = system.m(mesh.region.center)
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        # time-dependent - sinc
-        system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
+    # time-dependent - sin
+    system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
+    # with empty system dynamics, error will be raised due to
+    # check system dynamics.
+    system.dynamics = mm.Damping(alpha=1)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    # time-dependent - sinc
+    system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
 
-        self.calculator.delete(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        # time-dependent - function
-        def t_func(t):
-            if t < 1e-10:
-                return 1
-            elif t < 5e-10:
-                return (5e-10 - t) / 4e-10
-            else:
-                return 0
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
+    self.calculator.delete(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    # time-dependent - function
+    def t_func(t):
+        if t < 1e-10:
+            return 1
+        elif t < 5e-10:
+            return (5e-10 - t) / 4e-10
+        else:
+            return 0
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
 
-        # time-dependent - two terms
-        f = 10e9
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        def cos_wave(t):
-            return np.cos(2 * np.pi * f * t)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        def sin_wave(t):
-            return np.sin(2 * np.pi * f * t)
+    # time-dependent - two terms
+    f = 10e9
 
-        H_x = (1e6, 0, 0)
-        H_y = (0, 1e6, 0)
-        system.energy = mm.Zeeman(
-            H=H_x, func=cos_wave, dt=5e-12, name="xdir"
-        ) + mm.Zeeman(H=H_y, func="sin", t0=0, f=f, name="ydir")
-        td.drive(system, t=0.1e-9, n=100)
+    def cos_wave(t):
+        return np.cos(2 * np.pi * f * t)
 
-        assert not np.allclose(system.table.data["Bx_xdir"], 0)
-        assert np.allclose(system.table.data["By_xdir"], 0)
+    def sin_wave(t):
+        return np.sin(2 * np.pi * f * t)
 
-        assert np.allclose(system.table.data["Bx_ydir"], 0)
-        assert not np.allclose(system.table.data["By_ydir"], 0)
+    H_x = (1e6, 0, 0)
+    H_y = (0, 1e6, 0)
+    system.energy = mm.Zeeman(H=H_x, func=cos_wave, dt=5e-12, name="xdir") + mm.Zeeman(
+        H=H_y, func="sin", t0=0, f=f, name="ydir"
+    )
+    td.drive(system, t=0.1e-9, n=100)
 
-        assert np.isclose(
-            np.max(system.table.data["Bx_xdir"]), np.max(system.table.data["By_ydir"])
-        )
+    assert not np.allclose(system.table.data["Bx_xdir"], 0)
+    assert np.allclose(system.table.data["By_xdir"], 0)
 
-        H_x = (1e6, 0, 0)
-        H_y = (0, 1e6, 0)
-        system.energy = mm.Zeeman(
-            H=H_x, func=cos_wave, dt=5e-12, name="xdir"
-        ) + mm.Zeeman(H=H_y, func=sin_wave, dt=5e-12, name="ydir")
-        td.drive(system, t=0.1e-9, n=100)
+    assert np.allclose(system.table.data["Bx_ydir"], 0)
+    assert not np.allclose(system.table.data["By_ydir"], 0)
 
-        assert not np.allclose(system.table.data["Bx_xdir"], 0)
-        assert np.allclose(system.table.data["By_xdir"], 0)
+    assert np.isclose(
+        np.max(system.table.data["Bx_xdir"]), np.max(system.table.data["By_ydir"])
+    )
 
-        assert np.allclose(system.table.data["Bx_ydir"], 0)
-        assert not np.allclose(system.table.data["By_ydir"], 0)
+    H_x = (1e6, 0, 0)
+    H_y = (0, 1e6, 0)
+    system.energy = mm.Zeeman(H=H_x, func=cos_wave, dt=5e-12, name="xdir") + mm.Zeeman(
+        H=H_y, func=sin_wave, dt=5e-12, name="ydir"
+    )
+    td.drive(system, t=0.1e-9, n=100)
 
-        assert np.isclose(
-            np.max(system.table.data["Bx_xdir"]), np.max(system.table.data["By_ydir"])
-        )
+    assert not np.allclose(system.table.data["Bx_xdir"], 0)
+    assert np.allclose(system.table.data["By_xdir"], 0)
 
-        # time-dependent - tcl strings
-        tcl_strings = {}
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            set Hx [expr {sin($total_time * 1e10)}]
-            set dHx [expr {1e10 * cos($total_time * 1e10)}]
-            return [list $Hx 0 0 $dHx 0 0]
-        }
-        """
-        tcl_strings["energy"] = "Oxs_ScriptUZeeman"
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
+    assert np.allclose(system.table.data["Bx_ydir"], 0)
+    assert not np.allclose(system.table.data["By_ydir"], 0)
 
-        system.energy = mm.Zeeman(H=H, tcl_strings=tcl_strings)
+    assert np.isclose(
+        np.max(system.table.data["Bx_xdir"]), np.max(system.table.data["By_ydir"])
+    )
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    # time-dependent - tcl strings
+    tcl_strings = {}
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        set Hx [expr {sin($total_time * 1e10)}]
+        set dHx [expr {1e10 * cos($total_time * 1e10)}]
+        return [list $Hx 0 0 $dHx 0 0]
+    }
+    """
+    tcl_strings["energy"] = "Oxs_ScriptUZeeman"
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    system.energy = mm.Zeeman(H=H, tcl_strings=tcl_strings)
 
-        self.calculator.delete(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    def test_dict(self):
-        name = "zeeman_dict"
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        H = {"r1": (1e5, 0, 0), "r2": (0, 0, 1e5)}
-        Ms = 1e6
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+def test_zeeman_dict(zeeman_case):
+    self = zeeman_case
+    name = "zeeman_dict"
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+    H = {"r1": (1e5, 0, 0), "r2": (0, 0, 1e5)}
+    Ms = 1e6
 
-        assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
 
-        assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-    def test_time_dict(self):
-        name = "zeeman_dict"
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        H = {"r1": (1e5, 0, 0), "r2": (0, 0, 1e5)}
-        Ms = 1e6
+    assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        # with empty system dynamics, error will be raised due to
-        # check system dynamics.
-        system.dynamics = mm.Damping(alpha=1)
+    assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+def test_zeeman_time_dict(zeeman_case):
+    self = zeeman_case
+    name = "zeeman_dict"
 
-        assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
+    H = {"r1": (1e5, 0, 0), "r2": (0, 0, 1e5)}
+    Ms = 1e6
 
-        assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    # with empty system dynamics, error will be raised due to
+    # check system dynamics.
+    system.dynamics = mm.Damping(alpha=1)
 
-        # time-dependent - sin
-        system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    assert np.linalg.norm(np.subtract(system.m["r1"].mean(), (Ms, 0, 0))) < 1
 
-        # time-dependent - sinc
-        system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
+    assert np.linalg.norm(np.subtract(system.m["r2"].mean(), (0, 0, Ms))) < 1
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    # time-dependent - sin
+    system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        # time-dependent - function
-        def t_func(t):
-            if t < 1e-10:
-                return 1
-            elif t < 5e-10:
-                return (5e-10 - t) / 4e-10
-            else:
-                return 0
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
+    # time-dependent - sinc
+    system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        self.calculator.delete(system)
+    # time-dependent - function
+    def t_func(t):
+        if t < 1e-10:
+            return 1
+        elif t < 5e-10:
+            return (5e-10 - t) / 4e-10
+        else:
+            return 0
 
-    def test_field(self):
-        name = "zeeman_field"
+    system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
 
-        def value_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (1e6, 0, 0)
-            else:
-                return (0, 0, 1e6)
+    mesh = df.Mesh(region=self.region, cell=self.cell, subregions=self.subregions)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        H = df.Field(mesh, nvdim=3, value=value_fun)
-        Ms = 1e6
+    self.calculator.delete(system)
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+def test_zeeman_field(zeeman_case):
+    self = zeeman_case
+    name = "zeeman_field"
 
-        value = system.m((-2e-9, -2e-9, -2e-9))
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+    def value_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (1e6, 0, 0)
+        else:
+            return (0, 0, 1e6)
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-    def test_time_field(self):
-        name = "zeeman_field"
+    H = df.Field(mesh, nvdim=3, value=value_fun)
+    Ms = 1e6
 
-        def value_fun(pos):
-            x, y, z = pos
-            if x <= 0:
-                return (1e6, 0, 0)
-            else:
-                return (0, 0, 1e6)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        H = df.Field(mesh, nvdim=3, value=value_fun)
-        Ms = 1e6
+    value = system.m((-2e-9, -2e-9, -2e-9))
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-        system = mm.System(name=name)
-        system.energy = mm.Zeeman(H=H)
-        system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
 
-        value = system.m((-2e-9, -2e-9, -2e-9))
-        assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
+def test_zeeman_time_field(zeeman_case):
+    self = zeeman_case
+    name = "zeeman_field"
 
-        value = system.m((2e-9, 2e-9, 2e-9))
-        assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
+    def value_fun(pos):
+        x, y, z = pos
+        if x <= 0:
+            return (1e6, 0, 0)
+        else:
+            return (0, 0, 1e6)
 
-        # time-dependent - sin
-        system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
-        # with empty system dynamics, error will be raised due to
-        # check system dynamics.
-        system.dynamics = mm.Damping(alpha=1)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    H = df.Field(mesh, nvdim=3, value=value_fun)
+    Ms = 1e6
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    system = mm.System(name=name)
+    system.energy = mm.Zeeman(H=H)
+    system.m = df.Field(mesh, nvdim=3, value=(0, 1, 0), norm=Ms)
 
-        # time-dependent - sinc
-        system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
+    md = self.calculator.MinDriver()
+    md.drive(system)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    value = system.m((-2e-9, -2e-9, -2e-9))
+    assert np.linalg.norm(np.subtract(value, (Ms, 0, 0))) < 1e-3
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    value = system.m((2e-9, 2e-9, 2e-9))
+    assert np.linalg.norm(np.subtract(value, (0, 0, Ms))) < 1e-3
 
-        # time-dependent - function
-        def t_func(t):
-            omega = 2 * math.pi * 1e9
-            return [
-                math.cos(omega * t),
-                -math.sin(omega * t),
-                0,
-                math.sin(omega * t),
-                math.cos(omega * t),
-                0,
-                0,
-                0,
-                1,
-            ]
+    # time-dependent - sin
+    system.energy = mm.Zeeman(H=H, func="sin", f=1e9, t0=1e-12)
+    # with empty system dynamics, error will be raised due to
+    # check system dynamics.
+    system.dynamics = mm.Damping(alpha=1)
 
-        system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    # time-dependent - sinc
+    system.energy = mm.Zeeman(H=H, func="sinc", f=1e9, t0=0)
 
-        # time-dependent - tcl strings
-        tcl_strings = {}
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            set PI [expr {4*atan(1.)}]
-            set w [expr {1e9*2*$PI}]
-            set ct [expr {cos($w*$total_time)}]
-            set mct [expr {-1*$ct}]      ;# "mct" is "minus cosine (w)t"
-            set st [expr {sin($w*$total_time)}]
-            set mst [expr {-1*$st}]      ;# "mst" is "minus sine (w)t"
-            return [list  $ct $mst  0 \
-                          $st $ct   0 \
-                          0   0   1 \
-                          [expr {$w*$mst}] [expr {$w*$mct}] 0 \
-                          [expr {$w*$ct}]  [expr {$w*$mst}] 0 \
-                              0                0         0]
-        }"""
-        tcl_strings["energy"] = "Oxs_TransformZeeman"
-        tcl_strings["type"] = "general"
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
 
-        system.energy = mm.Zeeman(H=H, tcl_strings=tcl_strings)
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
 
-        mesh = df.Mesh(region=self.region, cell=self.cell)
-        system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+    # time-dependent - function
+    def t_func(t):
+        omega = 2 * math.pi * 1e9
+        return [
+            math.cos(omega * t),
+            -math.sin(omega * t),
+            0,
+            math.sin(omega * t),
+            math.cos(omega * t),
+            0,
+            0,
+            0,
+            1,
+        ]
 
-        td = self.calculator.TimeDriver()
-        td.drive(system, t=0.1e-9, n=20)
+    system.energy = mm.Zeeman(H=H, func=t_func, dt=1e-13)
 
-        self.calculator.delete(system)
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
+
+    # time-dependent - tcl strings
+    tcl_strings = {}
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        set PI [expr {4*atan(1.)}]
+        set w [expr {1e9*2*$PI}]
+        set ct [expr {cos($w*$total_time)}]
+        set mct [expr {-1*$ct}]      ;# "mct" is "minus cosine (w)t"
+        set st [expr {sin($w*$total_time)}]
+        set mst [expr {-1*$st}]      ;# "mst" is "minus sine (w)t"
+        return [list  $ct $mst  0 \
+                      $st $ct   0 \
+                      0   0   1 \
+                      [expr {$w*$mst}] [expr {$w*$mct}] 0 \
+                      [expr {$w*$ct}]  [expr {$w*$mst}] 0 \
+                          0                0         0]
+    }"""
+    tcl_strings["energy"] = "Oxs_TransformZeeman"
+    tcl_strings["type"] = "general"
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
+
+    system.energy = mm.Zeeman(H=H, tcl_strings=tcl_strings)
+
+    mesh = df.Mesh(region=self.region, cell=self.cell)
+    system.m = df.Field(mesh, nvdim=3, value=(1, 1, 1), norm=Ms)
+
+    td = self.calculator.TimeDriver()
+    td.drive(system, t=0.1e-9, n=20)
+
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/zhangli.py
+++ b/micromagnetictests/calculatortests/zhangli.py
@@ -1,306 +1,321 @@
 import math
+from types import SimpleNamespace
 
 import discretisedfield as df
 import micromagneticdata as mdata
 import micromagneticmodel as mm
 import pytest
 
+"""
+Each test defines a nanostrip with a domain wall in the left half. Current is
+applied to move the DW to the other side of the strip. Details of the current
+(direction, time dependence) are varied in the different tests.
+"""
 
-class TestZhangLi:
+
+@pytest.fixture
+def zhang_li_case(calculator):
+    case = SimpleNamespace()
+    case.calculator = calculator
+    """Prepare nano strip (l_x=200nm) with DW at x≈70nm."""
+    p1 = (0, 0, 0)
+    p2 = (200e-9, 20e-9, 5e-9)
+    cell = (5e-9, 5e-9, 5e-9)
+    subregions = {
+        "r1": df.Region(p1=(0, 0, 0), p2=(100e-9, 20e-9, 5e-9)),
+        "r2": df.Region(p1=(100e-9, 0, 0), p2=(200e-9, 20e-9, 5e-9)),
+    }
+
+    Ms = 5.8e5
+    A = 15e-12
+    K = 0.5e6
+    anisotropy_axis = (0, 0, 1)
+
+    def init_m(p):
+        if p[0] < 70e-9:
+            return (0.1, 0.1, -1)
+        return (0.1, 0.1, 1)
+
+    system = mm.System(name="strip_x")
+    system.energy = mm.Exchange(A=A) + mm.UniaxialAnisotropy(K=K, u=anisotropy_axis)
+    mesh = df.Mesh(p1=p1, p2=p2, cell=cell, subregions=subregions)
+    system.m = df.Field(mesh, nvdim=3, value=init_m, norm=Ms)
+
+    md = case.calculator.MinDriver()
+    md.drive(system)
+
+    # ensure that the initial state is as expected,
+    # a domain wall at x≈70 nm
+    assert 0.2 < system.m.orientation.z.mean() < 0.4
+    assert system.m.orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
+
+    case.u = 200
+    case.beta = 0.5
+    case.system = system
+
+    return case
+
+
+def test_zhang_li_scalar_u(zhang_li_case):
+    self = zhang_li_case
     """
-    Each test defines a nanostrip with a domain wall in the left half. Current is
-    applied to move the DW to the other side of the strip. Details of the current
-    (direction, time dependence) are varied in the different tests.
+    Uniform current in x direction.
     """
+    td = self.calculator.TimeDriver()
 
-    @pytest.fixture(autouse=True)
-    def _setup_calculator(self, calculator):
-        self.calculator = calculator
+    system = self.system
 
-    # inside setup_method it is not possible to use a fixture
-    @pytest.fixture(autouse=True)
-    def setup_method_as_fixture(self):
-        """Prepare nano strip (l_x=200nm) with DW at x≈70nm."""
-        p1 = (0, 0, 0)
-        p2 = (200e-9, 20e-9, 5e-9)
-        cell = (5e-9, 5e-9, 5e-9)
-        subregions = {
-            "r1": df.Region(p1=(0, 0, 0), p2=(100e-9, 20e-9, 5e-9)),
-            "r2": df.Region(p1=(100e-9, 0, 0), p2=(200e-9, 20e-9, 5e-9)),
-        }
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u=self.u, beta=self.beta)
+    )
+    td.drive(system, t=0.35e-9, n=1)
 
-        Ms = 5.8e5
-        A = 15e-12
-        K = 0.5e6
-        anisotropy_axis = (0, 0, 1)
+    # check that the domain wall moved to the right side of the strip to x≈130nm
+    assert -0.4 < system.m.orientation.z.mean() < -0.2
+    assert system.m.orientation.z.sel(x=(0, 120e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(x=(140e-9, 200e-9)).mean() > 0.95
 
-        def init_m(p):
-            if p[0] < 70e-9:
-                return (0.1, 0.1, -1)
-            return (0.1, 0.1, 1)
+    self.calculator.delete(system)
 
-        system = mm.System(name="strip_x")
-        system.energy = mm.Exchange(A=A) + mm.UniaxialAnisotropy(K=K, u=anisotropy_axis)
-        mesh = df.Mesh(p1=p1, p2=p2, cell=cell, subregions=subregions)
-        system.m = df.Field(mesh, nvdim=3, value=init_m, norm=Ms)
 
-        md = self.calculator.MinDriver()
-        md.drive(system)
+def test_zhang_li_time_func_scalar_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Uniform current in x direction with sin time dependence.
+    """
+    td = self.calculator.TimeDriver()
 
-        # ensure that the initial state is as expected,
-        # a domain wall at x≈70 nm
-        assert 0.2 < system.m.orientation.z.mean() < 0.4
-        assert system.m.orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
+    system = self.system
 
-        self.u = 200
-        self.beta = 0.5
-        self.system = system
+    f = 2 * math.pi / 0.6e-9
 
-    def test_scalar_u(self):
-        """
-        Uniform current in x direction.
-        """
-        td = self.calculator.TimeDriver()
+    def time_dep(t):
+        return math.sin(f * t)
 
-        system = self.system
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u=self.u, beta=self.beta, func=time_dep, dt=1e-13)
+    )
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u=self.u, beta=self.beta)
-        )
-        td.drive(system, t=0.35e-9, n=1)
+    # drive for one period and save two steps
+    td.drive(system, t=0.6e-9, n=2)
 
-        # check that the domain wall moved to the right side of the strip to x≈130nm
-        assert -0.4 < system.m.orientation.z.mean() < -0.2
-        assert system.m.orientation.z.sel(x=(0, 120e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(x=(140e-9, 200e-9)).mean() > 0.95
+    # use micromagneticdata to read the two saved steps
+    drive = mdata.Data(name=system.name)[-1]
 
-        self.calculator.delete(system)
+    # check that the domain wall moved to the right
+    # during the first half wave
+    assert -0.1 < drive[0].orientation.z.mean() < 0.1
+    assert drive[0].orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
+    assert drive[0].orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-    def test_time_func_scalar_u(self):
-        """
-        Uniform current in x direction with sin time dependence.
-        """
-        td = self.calculator.TimeDriver()
+    # check that the domain wall moved back to its initial position at x≈70nm
+    # during the second half wave
+    assert 0.2 < drive[1].orientation.z.mean() < 0.4
+    assert drive[1].orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
+    assert drive[1].orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
 
-        system = self.system
+    # self.calculator.delete(system)
 
-        f = 2 * math.pi / 0.6e-9
 
-        def time_dep(t):
-            return math.sin(f * t)
+def test_zhang_li_time_tcl_scalar_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Uniform current in x direction with sin time dependence.
+    """
+    td = self.calculator.TimeDriver()
+    system = self.system
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u=self.u, beta=self.beta, func=time_dep, dt=1e-13)
-        )
+    # time-dependence - tcl strings
+    tcl_strings = {}
+    # pre-compute frequency (pi not directly available)
+    # f = 2 * pi / 0.6e-9 = 10471975511.965977
+    tcl_strings["script"] = """proc TimeFunction { total_time } {
+        return [expr sin(10471975511.965977 * $total_time)]
+    }
+    """
+    tcl_strings["script_args"] = "total_time"
+    tcl_strings["script_name"] = "TimeFunction"
 
-        # drive for one period and save two steps
-        td.drive(system, t=0.6e-9, n=2)
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u=self.u, beta=self.beta, tcl_strings=tcl_strings)
+    )
 
-        # use micromagneticdata to read the two saved steps
-        drive = mdata.Data(name=system.name)[-1]
+    # drive for one period and save two steps
+    td.drive(system, t=0.6e-9, n=2)
 
-        # check that the domain wall moved to the right
-        # during the first half wave
-        assert -0.1 < drive[0].orientation.z.mean() < 0.1
-        assert drive[0].orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
-        assert drive[0].orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
+    # use micromagneticdata to read the two saved steps
+    drive = mdata.Data(name=system.name)[-1]
 
-        # check that the domain wall moved back to its initial position at x≈70nm
-        # during the second half wave
-        assert 0.2 < drive[1].orientation.z.mean() < 0.4
-        assert drive[1].orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
-        assert drive[1].orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
+    # check that the domain wall moved to the right
+    # during the first half wave
+    assert -0.1 < drive[0].orientation.z.mean() < 0.1
+    assert drive[0].orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
+    assert drive[0].orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-        # self.calculator.delete(system)
+    # check that the domain wall moved back to its initial position at x≈70nm
+    # during the second half wave
+    assert 0.2 < drive[1].orientation.z.mean() < 0.4
+    assert drive[1].orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
+    assert drive[1].orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
 
-    def test_time_tcl_scalar_u(self):
-        """
-        Uniform current in x direction with sin time dependence.
-        """
-        td = self.calculator.TimeDriver()
-        system = self.system
+    self.calculator.delete(system)
 
-        # time-dependence - tcl strings
-        tcl_strings = {}
-        # pre-compute frequency (pi not directly available)
-        # f = 2 * pi / 0.6e-9 = 10471975511.965977
-        tcl_strings["script"] = """proc TimeFunction { total_time } {
-            return [expr sin(10471975511.965977 * $total_time)]
-        }
-        """
-        tcl_strings["script_args"] = "total_time"
-        tcl_strings["script_name"] = "TimeFunction"
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u=self.u, beta=self.beta, tcl_strings=tcl_strings)
-        )
+def test_zhang_li_dict_scalar_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Current only in left half of the strip, defined with a dict.
+    """
+    td = self.calculator.TimeDriver()
 
-        # drive for one period and save two steps
-        td.drive(system, t=0.6e-9, n=2)
+    system = self.system
 
-        # use micromagneticdata to read the two saved steps
-        drive = mdata.Data(name=system.name)[-1]
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u={"r1": self.u, "r2": 0}, beta=self.beta)
+    )
+    td.drive(system, t=0.35e-9, n=1)
 
-        # check that the domain wall moved to the right
-        # during the first half wave
-        assert -0.1 < drive[0].orientation.z.mean() < 0.1
-        assert drive[0].orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
-        assert drive[0].orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
+    # check that the domain wall stops moving when the current stops at x≈100nm
+    assert -0.1 < system.m.orientation.z.mean() < 0.1
+    assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-        # check that the domain wall moved back to its initial position at x≈70nm
-        # during the second half wave
-        assert 0.2 < drive[1].orientation.z.mean() < 0.4
-        assert drive[1].orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
-        assert drive[1].orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
+    self.calculator.delete(system)
 
-        self.calculator.delete(system)
 
-    def test_dict_scalar_u(self):
-        """
-        Current only in left half of the strip, defined with a dict.
-        """
-        td = self.calculator.TimeDriver()
+def test_zhang_li_dict_vector_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Current only in left half of the strip, defined with a dict.
+    """
+    td = self.calculator.TimeDriver()
 
-        system = self.system
+    system = self.system
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u={"r1": self.u, "r2": 0}, beta=self.beta)
-        )
-        td.drive(system, t=0.35e-9, n=1)
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u={"r1": (self.u, 0, 0), "r2": (0, 0, 0)}, beta=self.beta)
+    )
+    td.drive(system, t=0.35e-9, n=1)
 
-        # check that the domain wall stops moving when the current stops at x≈100nm
-        assert -0.1 < system.m.orientation.z.mean() < 0.1
-        assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
+    # check that the domain wall stops moving when the current stops at x≈100nm
+    assert -0.1 < system.m.orientation.z.mean() < 0.1
+    assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-        self.calculator.delete(system)
+    self.calculator.delete(system)
 
-    def test_dict_vector_u(self):
-        """
-        Current only in left half of the strip, defined with a dict.
-        """
-        td = self.calculator.TimeDriver()
 
-        system = self.system
+def test_zhang_li_field_scalar_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Current only in left half of the strip, defined with a Field.
+    """
+    td = self.calculator.TimeDriver()
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u={"r1": (self.u, 0, 0), "r2": (0, 0, 0)}, beta=self.beta)
-        )
-        td.drive(system, t=0.35e-9, n=1)
+    system = self.system
 
-        # check that the domain wall stops moving when the current stops at x≈100nm
-        assert -0.1 < system.m.orientation.z.mean() < 0.1
-        assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
+    u_field = df.Field(
+        mesh=system.m.mesh, nvdim=1, value=lambda p: self.u if p[0] < 100e-9 else 0
+    )
 
-        self.calculator.delete(system)
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u=u_field, beta=self.beta)
+    )
+    td.drive(system, t=0.35e-9, n=1)
 
-    def test_field_scalar_u(self):
-        """
-        Current only in left half of the strip, defined with a Field.
-        """
-        td = self.calculator.TimeDriver()
+    # check that the domain wall stops moving when the current stops at x≈100nm
+    assert -0.1 < system.m.orientation.z.mean() < 0.1
+    assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-        system = self.system
+    self.calculator.delete(system)
 
-        u_field = df.Field(
-            mesh=system.m.mesh, nvdim=1, value=lambda p: self.u if p[0] < 100e-9 else 0
-        )
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u=u_field, beta=self.beta)
-        )
-        td.drive(system, t=0.35e-9, n=1)
+def test_zhang_li_field_vector_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Current only in left half of the strip, defined with a Field.
+    """
+    td = self.calculator.TimeDriver()
 
-        # check that the domain wall stops moving when the current stops at x≈100nm
-        assert -0.1 < system.m.orientation.z.mean() < 0.1
-        assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
+    system = self.system
 
-        self.calculator.delete(system)
+    u_field = df.Field(
+        mesh=system.m.mesh,
+        nvdim=3,
+        value=lambda p: (self.u, 0, 0) if p[0] < 100e-9 else (0, 0, 0),
+    )
 
-    def test_field_vector_u(self):
-        """
-        Current only in left half of the strip, defined with a Field.
-        """
-        td = self.calculator.TimeDriver()
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u=u_field, beta=self.beta)
+    )
+    td.drive(system, t=0.35e-9, n=1)
 
-        system = self.system
+    # check that the domain wall stops moving when the current stops at x≈100nm
+    assert -0.1 < system.m.orientation.z.mean() < 0.1
+    assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-        u_field = df.Field(
-            mesh=system.m.mesh,
-            nvdim=3,
-            value=lambda p: (self.u, 0, 0) if p[0] < 100e-9 else (0, 0, 0),
-        )
+    self.calculator.delete(system)
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u=u_field, beta=self.beta)
-        )
-        td.drive(system, t=0.35e-9, n=1)
 
-        # check that the domain wall stops moving when the current stops at x≈100nm
-        assert -0.1 < system.m.orientation.z.mean() < 0.1
-        assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
+def test_zhang_li_vector_u(zhang_li_case):
+    self = zhang_li_case
+    """
+    Strip oriented along y with uniform current applied in y direction.
+    """
+    md = self.calculator.MinDriver()
+    td = self.calculator.TimeDriver()
 
-        self.calculator.delete(system)
+    system = self.system
 
-    def test_vector_u(self):
-        """
-        Strip oriented along y with uniform current applied in y direction.
-        """
-        md = self.calculator.MinDriver()
-        td = self.calculator.TimeDriver()
+    # replace system m with strip along y
+    p1 = (0, 0, 0)
+    p2 = (20e-9, 200e-9, 5e-9)
+    cell = (5e-9, 5e-9, 5e-9)
 
-        system = self.system
+    def init_m(p):
+        if p[1] < 70e-9:
+            return (0.1, 0.1, -1)
+        return (0.1, 0.1, 1)
 
-        # replace system m with strip along y
-        p1 = (0, 0, 0)
-        p2 = (20e-9, 200e-9, 5e-9)
-        cell = (5e-9, 5e-9, 5e-9)
+    mesh = df.Mesh(p1=p1, p2=p2, cell=cell)
+    Ms = 5.8e5
+    system.m = df.Field(mesh, nvdim=3, value=init_m, norm=Ms)
 
-        def init_m(p):
-            if p[1] < 70e-9:
-                return (0.1, 0.1, -1)
-            return (0.1, 0.1, 1)
+    md.drive(system)
 
-        mesh = df.Mesh(p1=p1, p2=p2, cell=cell)
-        Ms = 5.8e5
-        system.m = df.Field(mesh, nvdim=3, value=init_m, norm=Ms)
+    # ensure that the initial state is as expected,
+    # a domain wall at y≈70 nm
+    assert 0.2 < system.m.orientation.z.mean() < 0.4
+    assert system.m.orientation.z.sel(y=(0, 60e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(y=(80e-9, 200e-9)).mean() > 0.95
 
-        md.drive(system)
+    system.dynamics = (
+        mm.Precession(gamma0=mm.consts.gamma0)
+        + mm.Damping(alpha=0.3)
+        + mm.ZhangLi(u=(0, self.u, 0), beta=self.beta)
+    )
+    td.drive(system, t=0.35e-9, n=1)
 
-        # ensure that the initial state is as expected,
-        # a domain wall at y≈70 nm
-        assert 0.2 < system.m.orientation.z.mean() < 0.4
-        assert system.m.orientation.z.sel(y=(0, 60e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(y=(80e-9, 200e-9)).mean() > 0.95
+    # check that the domain wall moved to the right side of the strip to y≈130nm
+    assert -0.4 < system.m.orientation.z.mean() < -0.2
+    assert system.m.orientation.z.sel(y=(0, 120e-9)).mean() < -0.95
+    assert system.m.orientation.z.sel(y=(140e-9, 200e-9)).mean() > 0.95
 
-        system.dynamics = (
-            mm.Precession(gamma0=mm.consts.gamma0)
-            + mm.Damping(alpha=0.3)
-            + mm.ZhangLi(u=(0, self.u, 0), beta=self.beta)
-        )
-        td.drive(system, t=0.35e-9, n=1)
-
-        # check that the domain wall moved to the right side of the strip to y≈130nm
-        assert -0.4 < system.m.orientation.z.mean() < -0.2
-        assert system.m.orientation.z.sel(y=(0, 120e-9)).mean() < -0.95
-        assert system.m.orientation.z.sel(y=(140e-9, 200e-9)).mean() > 0.95
-
-        self.calculator.delete(system)
+    self.calculator.delete(system)

--- a/micromagnetictests/calculatortests/zhangli.py
+++ b/micromagnetictests/calculatortests/zhangli.py
@@ -58,18 +58,17 @@ def zhang_li_case(calculator):
 
 
 def test_zhang_li_scalar_u(zhang_li_case):
-    self = zhang_li_case
     """
     Uniform current in x direction.
     """
-    td = self.calculator.TimeDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u=self.u, beta=self.beta)
+        + mm.ZhangLi(u=zhang_li_case.u, beta=zhang_li_case.beta)
     )
     td.drive(system, t=0.35e-9, n=1)
 
@@ -78,17 +77,16 @@ def test_zhang_li_scalar_u(zhang_li_case):
     assert system.m.orientation.z.sel(x=(0, 120e-9)).mean() < -0.95
     assert system.m.orientation.z.sel(x=(140e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_time_func_scalar_u(zhang_li_case):
-    self = zhang_li_case
     """
     Uniform current in x direction with sin time dependence.
     """
-    td = self.calculator.TimeDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     f = 2 * math.pi / 0.6e-9
 
@@ -98,7 +96,9 @@ def test_zhang_li_time_func_scalar_u(zhang_li_case):
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u=self.u, beta=self.beta, func=time_dep, dt=1e-13)
+        + mm.ZhangLi(
+            u=zhang_li_case.u, beta=zhang_li_case.beta, func=time_dep, dt=1e-13
+        )
     )
 
     # drive for one period and save two steps
@@ -119,16 +119,15 @@ def test_zhang_li_time_func_scalar_u(zhang_li_case):
     assert drive[1].orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
     assert drive[1].orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
 
-    # self.calculator.delete(system)
+    # zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_time_tcl_scalar_u(zhang_li_case):
-    self = zhang_li_case
     """
     Uniform current in x direction with sin time dependence.
     """
-    td = self.calculator.TimeDriver()
-    system = self.system
+    td = zhang_li_case.calculator.TimeDriver()
+    system = zhang_li_case.system
 
     # time-dependence - tcl strings
     tcl_strings = {}
@@ -144,7 +143,9 @@ def test_zhang_li_time_tcl_scalar_u(zhang_li_case):
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u=self.u, beta=self.beta, tcl_strings=tcl_strings)
+        + mm.ZhangLi(
+            u=zhang_li_case.u, beta=zhang_li_case.beta, tcl_strings=tcl_strings
+        )
     )
 
     # drive for one period and save two steps
@@ -165,22 +166,21 @@ def test_zhang_li_time_tcl_scalar_u(zhang_li_case):
     assert drive[1].orientation.z.sel(x=(0, 60e-9)).mean() < -0.95
     assert drive[1].orientation.z.sel(x=(80e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_dict_scalar_u(zhang_li_case):
-    self = zhang_li_case
     """
     Current only in left half of the strip, defined with a dict.
     """
-    td = self.calculator.TimeDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u={"r1": self.u, "r2": 0}, beta=self.beta)
+        + mm.ZhangLi(u={"r1": zhang_li_case.u, "r2": 0}, beta=zhang_li_case.beta)
     )
     td.drive(system, t=0.35e-9, n=1)
 
@@ -189,22 +189,23 @@ def test_zhang_li_dict_scalar_u(zhang_li_case):
     assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
     assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_dict_vector_u(zhang_li_case):
-    self = zhang_li_case
     """
     Current only in left half of the strip, defined with a dict.
     """
-    td = self.calculator.TimeDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u={"r1": (self.u, 0, 0), "r2": (0, 0, 0)}, beta=self.beta)
+        + mm.ZhangLi(
+            u={"r1": (zhang_li_case.u, 0, 0), "r2": (0, 0, 0)}, beta=zhang_li_case.beta
+        )
     )
     td.drive(system, t=0.35e-9, n=1)
 
@@ -213,26 +214,27 @@ def test_zhang_li_dict_vector_u(zhang_li_case):
     assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
     assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_field_scalar_u(zhang_li_case):
-    self = zhang_li_case
     """
     Current only in left half of the strip, defined with a Field.
     """
-    td = self.calculator.TimeDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     u_field = df.Field(
-        mesh=system.m.mesh, nvdim=1, value=lambda p: self.u if p[0] < 100e-9 else 0
+        mesh=system.m.mesh,
+        nvdim=1,
+        value=lambda p: zhang_li_case.u if p[0] < 100e-9 else 0,
     )
 
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u=u_field, beta=self.beta)
+        + mm.ZhangLi(u=u_field, beta=zhang_li_case.beta)
     )
     td.drive(system, t=0.35e-9, n=1)
 
@@ -241,28 +243,27 @@ def test_zhang_li_field_scalar_u(zhang_li_case):
     assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
     assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_field_vector_u(zhang_li_case):
-    self = zhang_li_case
     """
     Current only in left half of the strip, defined with a Field.
     """
-    td = self.calculator.TimeDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     u_field = df.Field(
         mesh=system.m.mesh,
         nvdim=3,
-        value=lambda p: (self.u, 0, 0) if p[0] < 100e-9 else (0, 0, 0),
+        value=lambda p: (zhang_li_case.u, 0, 0) if p[0] < 100e-9 else (0, 0, 0),
     )
 
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u=u_field, beta=self.beta)
+        + mm.ZhangLi(u=u_field, beta=zhang_li_case.beta)
     )
     td.drive(system, t=0.35e-9, n=1)
 
@@ -271,18 +272,17 @@ def test_zhang_li_field_vector_u(zhang_li_case):
     assert system.m.orientation.z.sel(x=(0, 90e-9)).mean() < -0.95
     assert system.m.orientation.z.sel(x=(110e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)
 
 
 def test_zhang_li_vector_u(zhang_li_case):
-    self = zhang_li_case
     """
     Strip oriented along y with uniform current applied in y direction.
     """
-    md = self.calculator.MinDriver()
-    td = self.calculator.TimeDriver()
+    md = zhang_li_case.calculator.MinDriver()
+    td = zhang_li_case.calculator.TimeDriver()
 
-    system = self.system
+    system = zhang_li_case.system
 
     # replace system m with strip along y
     p1 = (0, 0, 0)
@@ -309,7 +309,7 @@ def test_zhang_li_vector_u(zhang_li_case):
     system.dynamics = (
         mm.Precession(gamma0=mm.consts.gamma0)
         + mm.Damping(alpha=0.3)
-        + mm.ZhangLi(u=(0, self.u, 0), beta=self.beta)
+        + mm.ZhangLi(u=(0, zhang_li_case.u, 0), beta=zhang_li_case.beta)
     )
     td.drive(system, t=0.35e-9, n=1)
 
@@ -318,4 +318,4 @@ def test_zhang_li_vector_u(zhang_li_case):
     assert system.m.orientation.z.sel(y=(0, 120e-9)).mean() < -0.95
     assert system.m.orientation.z.sel(y=(140e-9, 200e-9)).mean() > 0.95
 
-    self.calculator.delete(system)
+    zhang_li_case.calculator.delete(system)

--- a/micromagnetictests/get_tests.py
+++ b/micromagnetictests/get_tests.py
@@ -12,7 +12,7 @@ def get_tests():
 
         Tests that can be imported from ``micromagnetictests``. The list
         consists of tuples, where the first element is the name of the tests,
-        whereas the second element is the test object (function or class).
+        whereas the second element is the test function.
 
     Examples
     --------
@@ -25,7 +25,5 @@ def get_tests():
 
     """
     for name, object in inspect.getmembers(mt.calculatortests):
-        if inspect.isclass(object) or inspect.isfunction(object):
-            starting_strings = ["__", "test_", "Test"]
-            if any([name.startswith(s) for s in starting_strings]):
-                yield (name, object)
+        if inspect.isfunction(object) and name.startswith("test_"):
+            yield (name, object)

--- a/micromagnetictests/tests/test_get_tests.py
+++ b/micromagnetictests/tests/test_get_tests.py
@@ -7,9 +7,7 @@ import micromagnetictests as mt
 def _module_test_functions():
     test_functions = {}
     for module_name in mt.calculatortests._MODULES:
-        module = importlib.import_module(
-            f"{mt.calculatortests.__name__}.{module_name}"
-        )
+        module = importlib.import_module(f"{mt.calculatortests.__name__}.{module_name}")
         for name, obj in inspect.getmembers(module, inspect.isfunction):
             if name.startswith("test_"):
                 assert name not in test_functions

--- a/micromagnetictests/tests/test_get_tests.py
+++ b/micromagnetictests/tests/test_get_tests.py
@@ -3,4 +3,4 @@ import micromagnetictests as mt
 
 def test_get_tests():
     tests = list(mt.get_tests())
-    assert len(tests) == 34
+    assert len(tests) == 106

--- a/micromagnetictests/tests/test_get_tests.py
+++ b/micromagnetictests/tests/test_get_tests.py
@@ -1,6 +1,28 @@
+import importlib
+import inspect
+
 import micromagnetictests as mt
+
+
+def _module_test_functions():
+    test_functions = {}
+    for module_name in mt.calculatortests._MODULES:
+        module = importlib.import_module(
+            f"{mt.calculatortests.__name__}.{module_name}"
+        )
+        for name, obj in inspect.getmembers(module, inspect.isfunction):
+            if name.startswith("test_"):
+                assert name not in test_functions
+                test_functions[name] = obj
+    return test_functions
 
 
 def test_get_tests():
     tests = list(mt.get_tests())
-    assert len(tests) == 106
+    test_names = [name for name, _ in tests]
+
+    assert test_names
+    assert len(test_names) == len(set(test_names))
+    assert all(name.startswith("test_") for name in test_names)
+    assert all(inspect.isfunction(obj) for _, obj in tests)
+    assert dict(tests) == _module_test_functions()


### PR DESCRIPTION
Refactor calculator tests from classes to functions

Flatten micromagnetictests calculator test classes into individual pytest
functions with shared setup moved into fixtures. Export the new function-level
tests explicitly so mumax3c and oommfc can continue importing the shared test
suite while making future test selection and removal more granular.